### PR TITLE
chore: Rename some `Run.__init__` arguments

### DIFF
--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -275,7 +275,7 @@ class NeptuneRunConflicting(NeptuneScaleError):
 {h1}
 ----NeptuneRunConflicting------------------------------------------------------
 {end}
-Run with specified `run_id` already exists, but has different creation parameters (`family` or `from_run_id`).
+Run with specified `run_id` already exists, but has different creation parameters (`family` or `fork_run_id`).
 
 {correct}Need help?{end}-> https://docs.neptune.ai/getting_help
 
@@ -420,7 +420,7 @@ class NeptuneSeriesStepNotAfterForkPoint(NeptuneScaleError):
 {h1}
 ----NeptuneSeriesStepNotAfterForkPoint-----------------------------------------
 {end}
-The series value must be greater than the step specified by the `from_step` argument.
+The series value must be greater than the step specified by the `fork_step` argument.
 
 {correct}Need help?{end}-> https://docs.neptune.ai/getting_help
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -262,7 +262,7 @@ def test_assign_experiment(api_token):
         api_token=api_token,
         family=family,
         run_id=run_id,
-        as_experiment="experiment_id",
+        experiment_name="experiment_id",
         mode="disabled",
     ):
         ...
@@ -283,8 +283,8 @@ def test_forking(api_token):
         api_token=api_token,
         family=family,
         run_id=run_id,
-        from_run_id="parent-run-id",
-        from_step=3.14,
+        fork_run_id="parent-run-id",
+        fork_step=3.14,
         mode="disabled",
     ):
         ...


### PR DESCRIPTION
This is a subset of #29, just the __init__ arguments

 * as_experiment -> experiment_name
 * from_run_id -> fork_run_id
 * from_step -> fork_step