### PR TITLE
Batching improvements

### DIFF
--- a/src/neptune_scale/core/components/aggregating_queue.py
+++ b/src/neptune_scale/core/components/aggregating_queue.py
@@ -81,7 +81,7 @@ class AggregatingQueue(Resource):
         while wait_remaining > 0:
             t0 = time.monotonic()
 
-            if elements_in_batch + 1 > self._max_elements_in_batch:
+            if elements_in_batch >= self._max_elements_in_batch:
                 break
 
             element = self._get_next(wait_remaining)

--- a/src/neptune_scale/core/components/aggregating_queue.py
+++ b/src/neptune_scale/core/components/aggregating_queue.py
@@ -101,16 +101,16 @@ class AggregatingQueue(Resource):
 
                 self.commit()
 
-                if not element.is_metadata_update:
-                    logger.debug("Batch closed due to first operation being run creation")
+                if not element.is_batchable:
+                    logger.debug("Batch closed due to first operation not being batchable")
                     break
             else:
                 if batch_key != element.operation_key:
                     logger.debug("Batch closed due to key mismatch")
                     break
 
-                if not element.is_metadata_update:
-                    logger.debug("Batch closed due to next operation being run creation")
+                if not element.is_batchable:
+                    logger.debug("Batch closed due to next operation not being batchable")
                     break
 
                 assert element.metadata_size is not None  # mypy, metadata update always has metadata size

--- a/src/neptune_scale/core/components/aggregating_queue.py
+++ b/src/neptune_scale/core/components/aggregating_queue.py
@@ -19,6 +19,7 @@ from neptune_scale.core.components.queue_element import (
 )
 from neptune_scale.core.logger import logger
 from neptune_scale.parameters import (
+    BATCH_WAIT_TIME_SECONDS,
     MAX_BATCH_SIZE,
     MAX_QUEUE_ELEMENT_SIZE,
 )
@@ -30,10 +31,12 @@ class AggregatingQueue(Resource):
         max_queue_size: int,
         max_elements_in_batch: int = MAX_BATCH_SIZE,
         max_queue_element_size: int = MAX_QUEUE_ELEMENT_SIZE,
+        wait_time: float = BATCH_WAIT_TIME_SECONDS,
     ) -> None:
         self._max_queue_size = max_queue_size
         self._max_elements_in_batch = max_elements_in_batch
         self._max_queue_element_size = max_queue_element_size
+        self._wait_time = wait_time
 
         self._queue: Queue[SingleOperation] = Queue(maxsize=max_queue_size)
         self._lock: RLock = RLock()
@@ -47,15 +50,15 @@ class AggregatingQueue(Resource):
         with self._lock:
             self._queue.put_nowait(element)
 
-    def _get_next(self) -> Optional[SingleOperation]:
-        # We can assume that each of queue elements are less than MAX_QUEUE_ELEMENT_SIZE
+    def _get_next(self, timeout: float) -> Optional[SingleOperation]:
+        # We can assume that each of queue elements are less than MAX_QUEUE_ELEMENT_SIZE because of MetadataSplitter.
         # We can assume that every queue element has the same project, run id and family
         with self._lock:
             if self._latest_unprocessed is not None:
                 return self._latest_unprocessed
 
             try:
-                self._latest_unprocessed = self._queue.get_nowait()
+                self._latest_unprocessed = self._queue.get(timeout=timeout)
                 return self._latest_unprocessed
             except Empty:
                 return None
@@ -71,12 +74,21 @@ class AggregatingQueue(Resource):
         batch_timestamp: Optional[float] = None
         batch_key: Optional[float] = None
         batch_bytes: int = 0
+        wait_remaining = self._wait_time
 
-        while (element := self._get_next()) is not None:
-            elements_in_batch += 1
+        # Pull operations off the queue until we either reach the maximum size, or
+        # the specified wait time has passed. This way we maximize the potential batch size.
+        while wait_remaining > 0:
+            t0 = time.monotonic()
 
-            if elements_in_batch > self._max_elements_in_batch:
+            if elements_in_batch + 1 > self._max_elements_in_batch:
                 break
+
+            element = self._get_next(wait_remaining)
+            if element is None:
+                break
+
+            elements_in_batch += 1
 
             if batch is None:
                 batch = RunOperation()
@@ -118,10 +130,12 @@ class AggregatingQueue(Resource):
                 batch_timestamp = element.timestamp
 
                 self.commit()
-        else:
-            logger.debug("Batch closed due to queue being empty")
+
+            t1 = time.monotonic()
+            wait_remaining -= t1 - t0
 
         if batch is None:
+            logger.debug(f"Batch is empty after {self._wait_time} seconds of waiting.")
             raise Empty
 
         assert batch_sequence_id is not None  # mypy

--- a/src/neptune_scale/core/components/aggregating_queue.py
+++ b/src/neptune_scale/core/components/aggregating_queue.py
@@ -66,7 +66,7 @@ class AggregatingQueue(Resource):
     def commit(self) -> None:
         self._latest_unprocessed = None
 
-    def get_nowait(self) -> BatchedOperations:
+    def get(self) -> BatchedOperations:
         start = time.process_time()
         elements_in_batch: int = 0
         batch: Optional[RunOperation] = None

--- a/src/neptune_scale/core/components/operations_queue.py
+++ b/src/neptune_scale/core/components/operations_queue.py
@@ -72,7 +72,7 @@ class OperationsQueue(Resource):
                         timestamp=self._last_timestamp,
                         operation=serialized_operation,
                         metadata_size=size,
-                        is_metadata_update=is_metadata_update,
+                        is_batchable=is_metadata_update,
                         operation_key=key,
                     ),
                     block=True,

--- a/src/neptune_scale/core/components/queue_element.py
+++ b/src/neptune_scale/core/components/queue_element.py
@@ -22,8 +22,8 @@ class SingleOperation(NamedTuple):
     timestamp: float
     # Protobuf serialized (RunOperation)
     operation: bytes
-    # Whether the operation is metadata update or not (run creation)
-    is_metadata_update: bool
+    # Whether the operation is batchable. Eg. metadata updates are, while run creations are not.
+    is_batchable: bool
     # Size of the metadata in the operation (without project, family, run_id etc.)
     metadata_size: Optional[int]
     # Update metadata key

--- a/src/neptune_scale/core/components/sync_process.py
+++ b/src/neptune_scale/core/components/sync_process.py
@@ -417,7 +417,7 @@ class SenderThread(Daemon, WithResources):
             return self._latest_unprocessed
 
         try:
-            self._latest_unprocessed = self._operations_queue.get_nowait()
+            self._latest_unprocessed = self._operations_queue.get()
             return self._latest_unprocessed
         except queue.Empty:
             return None

--- a/src/neptune_scale/parameters.py
+++ b/src/neptune_scale/parameters.py
@@ -8,6 +8,8 @@ MAX_BATCH_SIZE = 100000
 MAX_QUEUE_SIZE = 1000000
 MAX_MULTIPROCESSING_QUEUE_SIZE = 32767
 MAX_QUEUE_ELEMENT_SIZE = 1024 * 1024  # 1MB
+# Wait up to this many seconds for incoming operations before submitting a batch
+BATCH_WAIT_TIME_SECONDS = 1
 
 # Threads
 SYNC_THREAD_SLEEP_TIME = 2

--- a/tests/unit/test_aggregating_queue.py
+++ b/tests/unit/test_aggregating_queue.py
@@ -30,7 +30,7 @@ def test__simple():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update.ByteSize(),
         operation_key=None,
     )
@@ -58,7 +58,7 @@ def test__max_size_exceeded():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=0,
         operation_key=None,
     )
@@ -66,7 +66,7 @@ def test__max_size_exceeded():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=0,
         operation_key=None,
     )
@@ -106,7 +106,7 @@ def test__batch_size_limit():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update1.ByteSize(),
         operation_key=None,
     )
@@ -114,7 +114,7 @@ def test__batch_size_limit():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update2.ByteSize(),
         operation_key=None,
     )
@@ -154,7 +154,7 @@ def test__batching():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update1.ByteSize(),
         operation_key=None,
     )
@@ -162,7 +162,7 @@ def test__batching():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update2.ByteSize(),
         operation_key=None,
     )
@@ -205,7 +205,7 @@ def test__not_merge_two_run_creation():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=None,
     )
@@ -213,7 +213,7 @@ def test__not_merge_two_run_creation():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=None,
     )
@@ -271,7 +271,7 @@ def test__not_merge_run_creation_with_metadata_update():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=None,
     )
@@ -279,7 +279,7 @@ def test__not_merge_run_creation_with_metadata_update():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update.ByteSize(),
         operation_key=None,
     )
@@ -337,7 +337,7 @@ def test__merge_same_key():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update1.ByteSize(),
         operation_key=1.0,
     )
@@ -345,7 +345,7 @@ def test__merge_same_key():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=True,
+        is_batchable=True,
         metadata_size=update2.ByteSize(),
         operation_key=1.0,
     )
@@ -389,7 +389,7 @@ def test__not_merge_two_different_steps():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=1.0,
     )
@@ -397,7 +397,7 @@ def test__not_merge_two_different_steps():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=2.0,
     )
@@ -455,7 +455,7 @@ def test__not_merge_step_with_none():
         sequence_id=1,
         timestamp=time.process_time(),
         operation=operation1.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=1.0,
     )
@@ -463,7 +463,7 @@ def test__not_merge_step_with_none():
         sequence_id=2,
         timestamp=time.process_time(),
         operation=operation2.SerializeToString(),
-        is_metadata_update=False,
+        is_batchable=False,
         metadata_size=0,
         operation_key=None,
     )

--- a/tests/unit/test_aggregating_queue.py
+++ b/tests/unit/test_aggregating_queue.py
@@ -42,7 +42,7 @@ def test__simple():
     queue.put_nowait(element=element)
 
     # then
-    assert queue.get_nowait() == BatchedOperations(
+    assert queue.get() == BatchedOperations(
         sequence_id=1,
         timestamp=element.timestamp,
         operation=element.operation,
@@ -92,7 +92,7 @@ def test__empty():
 
     # when
     with pytest.raises(Empty):
-        _ = queue.get_nowait()
+        _ = queue.get()
 
 
 @freeze_time("2024-09-01")
@@ -127,12 +127,12 @@ def test__batch_size_limit():
     queue.put_nowait(element=element2)
 
     # then
-    assert queue.get_nowait() == BatchedOperations(
+    assert queue.get() == BatchedOperations(
         sequence_id=1,
         timestamp=element1.timestamp,
         operation=element1.operation,
     )
-    assert queue.get_nowait() == BatchedOperations(
+    assert queue.get() == BatchedOperations(
         sequence_id=2,
         timestamp=element2.timestamp,
         operation=element2.operation,
@@ -175,7 +175,7 @@ def test__batching():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2
@@ -226,7 +226,7 @@ def test__not_merge_two_run_creation():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 1
@@ -241,7 +241,7 @@ def test__not_merge_two_run_creation():
     assert batch.create == create1
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2
@@ -292,7 +292,7 @@ def test__not_merge_run_creation_with_metadata_update():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 1
@@ -307,7 +307,7 @@ def test__not_merge_run_creation_with_metadata_update():
     assert batch.create == create
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2
@@ -358,7 +358,7 @@ def test__merge_same_key():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2
@@ -410,7 +410,7 @@ def test__not_merge_two_different_steps():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 1
@@ -425,7 +425,7 @@ def test__not_merge_two_different_steps():
     assert batch.update == update1
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2
@@ -476,7 +476,7 @@ def test__not_merge_step_with_none():
     queue.put_nowait(element=element2)
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 1
@@ -491,7 +491,7 @@ def test__not_merge_step_with_none():
     assert batch.update == update1
 
     # when
-    result = queue.get_nowait()
+    result = queue.get()
 
     # then
     assert result.sequence_id == 2


### PR DESCRIPTION
Key points:
 * Have `AggregatingQueue` wait a predefined time for incoming operations, to maximize batch size
 * `InternalQueueFeederThread` blocks on the queue with a timeout, reducing latency