### PR TITLE
fix: Strip quotes from env vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ authors = ["neptune.ai <contact@neptune.ai>"]
 repository = "https://github.com/neptune-ai/neptune-client-scale"
 readme = "README.md"
 license = "Apache License 2.0"
-packages = [
-    { include = "neptune_scale", from = "src" },
-]
+packages = [{ include = "neptune_scale", from = "src" }]
 include = []
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -93,4 +91,4 @@ no_implicit_optional = "True"
 check_untyped_defs = "True"
 warn_return_any = "True"
 show_error_codes = "True"
-warn_unused_ignores = "True"
+# warn_unused_ignores = "True"

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -265,7 +265,8 @@ class Run(WithResources, AbstractContextManager):
         self._exit_func: Optional[Callable[[], None]] = atexit.register(self._close)
 
         if platform.system() != "Windows":
-            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore [attr-defined]
+            # Ignoring the type because the signal module is not available on Windows
+            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore[attr-defined]  # mypy: ignore-errors
 
         if not resume:
             self._create_run(

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -266,7 +266,7 @@ class Run(WithResources, AbstractContextManager):
 
         if platform.system() != "Windows":
             # Ignoring the type because the signal module is not available on Windows
-            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore[attr-defined]  # mypy: ignore-errors
+            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore
 
         if not resume:
             self._create_run(

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -171,13 +171,17 @@ class Run(WithResources, AbstractContextManager):
             raise ValueError("`max_queue_size` must be greater than 0.")
 
         project = project or os.environ.get(PROJECT_ENV_NAME)
-        if project is None:
+        if project:
+            project = project.strip('"').strip("'")
+        else:
             raise NeptuneProjectNotProvided()
         assert project is not None  # mypy
         input_project: str = project
 
         api_token = api_token or os.environ.get(API_TOKEN_ENV_NAME)
-        if api_token is None:
+        if api_token:
+            api_token = api_token.strip('"').strip("'")
+        else:
             raise NeptuneApiTokenNotProvided()
         assert api_token is not None  # mypy
         input_api_token: str = api_token
@@ -261,7 +265,7 @@ class Run(WithResources, AbstractContextManager):
         self._exit_func: Optional[Callable[[], None]] = atexit.register(self._close)
 
         if platform.system() != "Windows":
-            signal.signal(signal.SIGCHLD, self._handle_signal)
+            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore [attr-defined]
 
         if not resume:
             self._create_run(

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -179,9 +179,7 @@ class Run(WithResources, AbstractContextManager):
         input_project: str = project
 
         api_token = api_token or os.environ.get(API_TOKEN_ENV_NAME)
-        if api_token:
-            api_token = api_token.strip('"').strip("'")
-        else:
+        if api_token is None:
             raise NeptuneApiTokenNotProvided()
         assert api_token is not None  # mypy
         input_api_token: str = api_token

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -266,7 +266,7 @@ class Run(WithResources, AbstractContextManager):
 
         if platform.system() != "Windows":
             # Ignoring the type because the signal module is not available on Windows
-            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore
+            signal.signal(signal.SIGCHLD, self._handle_signal)  # type: ignore[attr-defined]
 
         if not resume:
             self._create_run(


### PR DESCRIPTION
Without quotes being stripped, Neptune would not recognize the API TOKEN and Project name, resulting in a `NeptuneUnauthorizedError`