### PR TITLE
chore: Forced `step` and `timestamp` to be keyword only

### DIFF
--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -402,9 +402,10 @@ class Run(WithResources, AbstractContextManager):
 
     def log_metrics(
         self,
+        data: Dict[str, Union[float, int]],
+        *,
         step: Optional[Union[float, int]] = None,
         timestamp: Optional[datetime] = None,
-        data: Optional[Dict[str, Union[float, int]]] = None,
     ) -> None:
         """
         Logs the specified metrics to a Neptune run.
@@ -419,15 +420,14 @@ class Run(WithResources, AbstractContextManager):
         Use namespaces to structure the metadata into meaningful categories.
 
         Args:
-            step: Index of the log entry. Must be increasing.
-                If not specified, the log_metrics() call increments the step starting from the highest
-                already logged value.
-                Tip: Using float rather than int values can be useful, for example, when logging substeps in a batch.
-            timestamp: Time of logging the metadata.
             data: Dictionary of metrics to log.
                 Each metric value is associated with a step.
                 To log multiple metrics at once, pass multiple key-value pairs.
-
+            step (optional): Index of the log entry. Must be increasing.
+                If not specified, the log_metrics() call increments the step starting from the highest
+                already logged value.
+                Tip: Using float rather than int values can be useful, for example, when logging substeps in a batch.
+            timestamp (optional): Time of logging the metadata. If not specified, the current time is used.
 
         Examples:
             ```

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -435,8 +435,8 @@ class Run(WithResources, AbstractContextManager):
 
             with Run(...) as run:
                 run.log_metrics(
+                    {"loss": 0.14, "acc": 0.78},
                     step=1.2,
-                    data={"loss": 0.14, "acc": 0.78},
                 )
             ```
         """


### PR DESCRIPTION
Since `step` and `timestamp` are optional, making them keyword-only will let users log metrics more quickly if only passing `data` without having to pass it as a kwarg - `run.log_metrics({"acc:0.98"})` instead of `run.log_metrics(data={"acc:0.98"})`.

