### PR TITLE
Fix lock is not owned error in error handling block

### DIFF
--- a/src/neptune_scale/core/components/sync_process.py
+++ b/src/neptune_scale/core/components/sync_process.py
@@ -482,7 +482,8 @@ class SenderThread(Daemon, WithResources):
                     self._last_put_seq_wait.notify_all()
         except Exception as e:
             self._errors_queue.put(e)
-            self._last_put_seq_wait.notify_all()
+            with self._last_put_seq_wait:
+                self._last_put_seq_wait.notify_all()
             self.interrupt()
             raise NeptuneSynchronizationStopped() from e
 


### PR DESCRIPTION
Whenever any exception is thrown from the block doing the api calls, it's causes a second error
```
line 278, in notify
    assert self._lock._semlock._is_mine(), 'lock is not owned'
```
because of a missing lock acquisition in the except block.

Simply acquiring it seems safe, given that the other except block does just that.