### PR TITLE
Add `ProcessLink` class

### DIFF
--- a/src/neptune_scale/core/process_link.py
+++ b/src/neptune_scale/core/process_link.py
@@ -1,0 +1,255 @@
+import multiprocessing
+import os
+import queue
+import threading
+from functools import partial
+from multiprocessing.connection import Connection
+from typing import (
+    Any,
+    Callable,
+    Optional,
+)
+
+from neptune_scale.core.components.daemon import Daemon
+from neptune_scale.core.logger import logger
+
+POLL_TIMEOUT = 0.1
+
+
+class ProcessLink:
+    """Used for bidirectional monitoring and control channel between two processes.
+
+    When a linked process terminates, the `on_link_closed` callback provided in `start()` will be called.
+    This way both the parent and child process know when any of them terminated.
+
+    Note that:
+     * you MUST call `start()` on the link in both parent and child processes
+     * the callback will be called from a thread
+
+    Typically, you would use it like this:
+        import time
+
+        # Child process worker
+        def worker(link):
+            # Required for the link to work
+            link.start()
+            # Do some work
+            time.sleep(1)
+
+        # Parent process
+        link = ProcessLink()
+        child = multiprocessing.Process(target=worker, args=(link,))
+        child.start()
+
+        link.start(on_link_closed=lambda l: print('child closed'))
+        link.join() # Wait until the other side is terminated
+
+    See tests/unit/test_process_link.py for more examples.
+    """
+
+    def __init__(self) -> None:
+        self._pipes = multiprocessing.Pipe()
+
+        self._on_link_closed: Optional[Callable[[ProcessLink], Any]] = None
+        self._on_message_received: Optional[Callable[[ProcessLink, Any], Any]] = None
+
+        # PID of the process that created this object, which should be the parent process.
+        # Used to detect if we're calling start() from child or parent.
+        self._parent_pid = os.getpid()
+
+        # These fields below are initialized in the start() method, as they cannot be pickled
+        # and thus passed to a multiprocessing.Process()
+
+        self._worker: Optional[ProcessLinkWorker] = None
+        # Signal end of the startup procedure
+        self._start_done: Optional[threading.Event] = None
+        self._msg_queue: Optional[queue.SimpleQueue] = None
+
+    def start(
+        self,
+        *,
+        timeout: float = 5.0,
+        on_link_closed: Optional[Callable[["ProcessLink"], Any]] = None,
+        on_message_received: Optional[Callable[["ProcessLink", Any], Any]] = None,
+    ) -> bool:
+        """Start the monitoring thread and wait for `timeout` seconds for the other side to start.
+
+        Returns True if the other side is started successfully within the given timeout, False otherwise.
+
+        You can provide callbacks for when the link is closed or when a message is received. The callbacks should
+        accept the `ProcessLink` instance as the first argument.
+
+        Note that during this call the `on_terminate` callback can already be called, for example
+        if the process fails to start properly.
+
+        This method is NOT thread-safe. It should be called only once, preferably from the main thread.
+        """
+
+        if self._worker:
+            raise RuntimeError("start() can only be called once")
+
+        self._on_link_closed = on_link_closed
+        self._on_message_received = on_message_received
+        self._msg_queue = queue.SimpleQueue()
+
+        # Close the "other" end of the pipe depending on which process we're in
+        if os.getpid() == self._parent_pid:
+            self._pipes[1].close()
+            conn = self._pipes[0]
+        else:
+            self._pipes[0].close()
+            conn = self._pipes[1]
+
+        del self._pipes
+        self._start_done = threading.Event()
+
+        self._worker = ProcessLinkWorker(
+            conn,
+            self._start_done,
+            start_timeout=timeout,
+            msg_queue=self._msg_queue,
+            on_link_closed=partial(self._on_link_closed, self) if self._on_link_closed else None,
+            on_message_received=partial(self._on_message_received, self) if self._on_message_received else None,
+        )
+        self._worker.start()
+
+        return self._start_done.wait(timeout=timeout) and not self._worker.is_link_closed
+
+    def stop(self, wait: bool = True, timeout: Optional[float] = None) -> None:
+        """Stop monitoring the link. The other side will be notified. The `on_link_closed` callback will NOT be called
+        in the calling process. You can optionally wait for the worker to finish.
+        """
+
+        if not self._worker:
+            raise RuntimeError("You must call start() before calling stop()")
+
+        self._worker.stop_link()
+        if wait:
+            self.join(timeout)
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """
+        Wait for the link monitor to finish. This happens only after the other side is terminated or stop() is called.
+        """
+
+        if not self._worker:
+            raise RuntimeError("You must call start() before calling join()")
+
+        self._worker.join(timeout=timeout)
+
+    def send(self, message: Any) -> None:
+        if not self._msg_queue:
+            raise RuntimeError("You must call start() before sending messages")
+
+        self._msg_queue.put(message)
+
+
+class ProcessLinkWorker(Daemon):
+    def __init__(
+        self,
+        conn: Connection,
+        start_done_event: threading.Event,
+        start_timeout: float,
+        msg_queue: queue.SimpleQueue,
+        *,
+        on_link_closed: Optional[Callable[[], Any]] = None,
+        on_message_received: Optional[Callable[[Any], Any]] = None,
+    ):
+        super().__init__(sleep_time=0, name="ProcessLink")
+
+        # Indicates if the other side is alive
+        self._closed = False
+
+        self._conn = conn
+        self._start_timeout = start_timeout
+        self._msg_queue = msg_queue
+        self._on_link_closed = on_link_closed
+        self._on_message_received = on_message_received
+
+        # Signal end of the startup procedure
+        self._start_done = start_done_event
+        # Set if we've started stopping the link
+        self._stop_event = threading.Event()
+        self._lock = threading.RLock()
+
+    @property
+    def is_link_closed(self) -> bool:
+        with self._lock:
+            return self._closed
+
+    def run(self) -> None:
+        # Before entering the main loop we send and receive a single message.
+        # This allows us to make sure that the process on the other end of the pipe is started successfully.
+        success = False
+        try:
+            self._conn.send("started")
+
+            # Give the child process some time for startup
+            if not self._conn.poll(timeout=self._start_timeout):
+                raise RuntimeError(f"Other side failed to start within {self._start_timeout} seconds")
+
+            if (msg := self._conn.recv()) != "started":
+                raise RuntimeError(f"Invalid challenge response: {msg}")
+            success = True
+        except Exception as e:
+            logger.error(f"{self}: unexpected error while sending data: {e}")
+            with self._lock:
+                self._closed = True
+            self.interrupt()
+
+        self._start_done.set()
+
+        # ProcessLink is guaranteed not to call on_link_close after stop() has been called so make sure it is so
+        if not success and not self._stop_event.is_set():
+            self._safe_callback(self._on_link_closed)
+        else:
+            super().run()
+
+    def work(self) -> None:
+        if self._stop_event.is_set():
+            # This will notify the other side about us closing the link
+            if not self._conn.closed:
+                self._conn.close()
+
+            self.interrupt()
+            return
+
+        try:
+            try:
+                out = self._msg_queue.get_nowait()
+                self._conn.send(out)
+            except queue.Empty:
+                pass
+
+            # Don't block on self._conn.recv() indefinitely, so we can react to stopping the link
+            if not self._conn.poll(timeout=POLL_TIMEOUT) or not self.is_running():
+                return
+
+            msg = self._conn.recv()
+            if not self._stop_event.is_set():
+                self._safe_callback(self._on_message_received, msg)
+        except Exception as e:
+            # EOFError is expected when the other side closes the connection.
+            if not isinstance(e, EOFError):
+                logger.error(f"{self}: unexpected error while receiving data: {e}")
+
+            with self._lock:
+                self._closed = True
+
+            if not self._stop_event.is_set():
+                self._safe_callback(self._on_link_closed)
+                self._conn.close()
+
+            self.interrupt()
+
+    def stop_link(self) -> None:
+        self._stop_event.set()
+
+    def _safe_callback(self, func: Optional[Callable[..., Any]], *args: Any, **kwargs: Any) -> None:
+        if func is None:
+            return
+
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            logger.error(f"{self}: exception while calling user callback {func}: {e}")

--- a/src/neptune_scale/core/process_link.py
+++ b/src/neptune_scale/core/process_link.py
@@ -45,6 +45,15 @@ class ProcessLink:
         link.join() # Wait until the other side is terminated
 
     See tests/unit/test_process_link.py for more examples.
+
+    The main idea behind this is to create pipes shared between child and parent processes.
+    When any process terminates, the other one will receive errors when reading the pipe.
+
+    We could use the `signal` module (registering for SIGCHLD), but this approach has several problems:
+     - registering for SIGCHLD is not available on Windows
+     - registering for SIGCHLD is brittle, because users might register their own signal handlers, which would either
+       break our library, or user code
+     - the child process has no way to detect if the parent process dies
     """
 
     def __init__(self) -> None:

--- a/tests/unit/test_process_link.py
+++ b/tests/unit/test_process_link.py
@@ -1,0 +1,144 @@
+import threading
+import time
+from functools import partial
+from multiprocessing import (
+    Condition,
+    Event,
+    Process,
+)
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+from pytest import fixture
+
+from neptune_scale.core.process_link import ProcessLink
+
+LINK_STOP_TIMEOUT = 3
+
+
+@fixture
+def link() -> ProcessLink:
+    return ProcessLink()
+
+
+def start_link_worker(
+    link: ProcessLink,
+    *,
+    sleep_before: Optional[float] = None,
+    sleep_after: Optional[float] = None,
+    should_start: bool = True,
+    cond: Optional[Condition] = None,
+    event: Optional[Event] = None,
+):
+    if sleep_before:
+        time.sleep(sleep_before)
+
+    if should_start:
+        link.start()
+
+    if sleep_after:
+        time.sleep(sleep_after)
+
+    if cond is not None:
+        with cond:
+            cond.notify_all()
+
+    if event is not None:
+        event.set()
+
+    print("child exiting")
+
+
+@pytest.mark.parametrize("sleep", [0, 0.001, 0.5, 1])
+def test__successful_startup_and_termination(link, sleep):
+    event = Event()
+
+    p = Process(target=start_link_worker, args=(link,), kwargs=dict(sleep_after=sleep, event=event))
+    t0 = time.monotonic()
+    p.start()
+
+    def callback(_):
+        # Make sure we only get notified after the child process is dead
+        assert time.monotonic() - t0 >= sleep
+        assert event.is_set()
+
+    link.start(on_link_closed=callback)
+
+
+def test__join(link):
+    """ProcessLink should only join after the other side terminates"""
+    event = Event()
+
+    p = Process(target=start_link_worker, args=(link,), kwargs=dict(event=event))
+    p.start()
+
+    mock = Mock()
+    link.start(on_link_closed=mock)
+    link.join()
+
+    assert event.is_set()
+    mock.assert_called()
+
+
+def test__stop_does_not_call_on_link_closed(link):
+    """After we call stop() we should never have the on_link_closed callback called."""
+
+    p = Process(target=start_link_worker, args=(link,), kwargs=dict(sleep_after=1))
+    p.start()
+
+    mock = Mock()
+    link.start(on_link_closed=mock)
+    link.stop()
+
+    mock.assert_not_called()
+
+
+def test__start_timeout_no_start_on_child_end(link):
+    """Child doesn't start the link at all"""
+
+    p = Process(target=start_link_worker, args=(link,), kwargs=dict(should_start=False))
+    p.start()
+
+    assert not link.start(timeout=0.5)
+
+
+def test__delayed_start_timeout(link):
+    """Child starts the link but only after the allowed timeout."""
+
+    p = Process(target=start_link_worker, args=(link,), kwargs=dict(sleep_before=1))
+    p.start()
+
+    assert not link.start(timeout=0.5)
+
+
+def pong_on_message_received(link, message, event):
+    if message == "ping":
+        link.send("pong")
+    else:
+        link.send("?")
+    event.set()
+
+
+def pong_worker(link):
+    event = threading.Event()
+    link.start(on_message_received=partial(pong_on_message_received, event=event))
+
+    assert event.wait(1)
+
+
+def test__message_passing(link):
+    """Start a worker that responds to "ping" with "pong" and check if the message is passed correctly."""
+
+    event = threading.Event()
+    p = Process(target=pong_worker, args=(link,))
+    p.start()
+
+    def on_msg(_, message):
+        assert message == "pong"
+        event.set()
+
+    link.start(on_message_received=on_msg)
+    link.send("ping")
+
+    assert event.wait(1)


### PR DESCRIPTION
The purpose of this class is to reliably monitor if a child process died, and vice-versa.

Currently we're using the `signal` module, which has several problems:
* registering for `SIGCHLD` is not available on Windows. This is the standard way for the OS to notify about child process termination.
* registering for `SIGCHLD` is brittle, because users might register their own signal handlers, which would either break our library, or user code
* the child process has no way to detect if the parent process dies

This class works around those problems by sharing pipes between processes. A pipe will be closed by the OS on process exit, and this is something that the process on other end of the pipe is able to detect.

Additionally, a "free" benefit is that we can use `ProcessLink` as a control channel between processes, by sending simple messages which could be used for signalling the worker process to "stop synchronization", "flush buffers" and so on
