### PR TITLE
Remove the `family` parameter from `Run.__init__()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ from neptune_scale import Run
 
 run = Run(
     experiment_name="ExperimentName",
-    family="RunFamilyName",  # must be the same for related runs
     run_id="SomeUniqueRunIdentifier",
 )
 ```
@@ -130,7 +129,6 @@ __Parameters__
 
 | Name             | Type             | Default | Description                                                               |
 |------------------|------------------|---------|---------------------------------------------------------------------------|
-| `family`         | `str`            | -       | Identifies related runs. All runs of the same lineage must have the same `family` value. That is, forking is only possible within the same family. Max length: 128 bytes. |
 | `run_id`         | `str`            | -       | Identifier of the run. Must be unique within the project. Max length: 128 bytes. |
 | `project`        | `str`, optional  | `None`  | Name of a project in the form `workspace-name/project-name`. If `None`, the value of the `NEPTUNE_PROJECT` environment variable is used. |
 | `api_token`      | `str`, optional  | `None`  | Your Neptune API token or a service account's API token. If `None`, the value of the `NEPTUNE_API_TOKEN` environment variable is used. To keep your token secure, don't place it in source code. Instead, save it as an environment variable. |
@@ -156,7 +154,6 @@ from neptune_scale import Run
 with Run(
     project="team-alpha/project-x",
     api_token="h0dHBzOi8aHR0cHM6...Y2MifQ==",
-    family="aquarium",
     run_id="likable-barracuda",
 ) as run:
     ...
@@ -173,7 +170,6 @@ To restart an experiment, create a forked run:
 
 ```python
 with Run(
-    family="aquarium",
     run_id="adventurous-barracuda",
     experiment_name="swim-further",
     fork_run_id="likable-barracuda",
@@ -186,7 +182,6 @@ Continue a run:
 
 ```python
 with Run(
-    family="aquarium",
     run_id="likable-barracuda",  # a Neptune run with this ID already exists
     resume=True,
 ) as run:

--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -278,7 +278,7 @@ class NeptuneRunConflicting(NeptuneScaleError):
 {h1}
 ----NeptuneRunConflicting------------------------------------------------------
 {end}
-Run with specified `run_id` already exists, but has different creation parameters (`family` or `fork_run_id`).
+Run with specified `run_id` already exists, but has a different `fork_run_id` parameter.
 
 {correct}Need help?{end}-> Contact support@neptune.ai
 

--- a/src/neptune_scale/parameters.py
+++ b/src/neptune_scale/parameters.py
@@ -1,6 +1,5 @@
 # Input validation
 MAX_RUN_ID_LENGTH = 128
-MAX_FAMILY_LENGTH = 128
 MAX_EXPERIMENT_NAME_LENGTH = 730
 
 # Operations queue

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -17,7 +17,6 @@ def api_token():
 # Set short timeouts on blocking operations for quicker test execution
 @pytest.fixture(autouse=True, scope="session")
 def short_timeouts():
-    import neptune_scale
     import neptune_scale.core.components
 
     patch = pytest.MonkeyPatch()
@@ -41,10 +40,9 @@ def test_context_manager(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # when
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled"):
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled"):
         ...
 
     # then
@@ -55,10 +53,9 @@ def test_close(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # and
-    run = Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled")
+    run = Run(project=project, api_token=api_token, run_id=run_id, mode="disabled")
 
     # when
     run.close()
@@ -67,34 +64,16 @@ def test_close(api_token):
     assert True
 
 
-def test_family_too_long(api_token):
-    # given
-    project = "workspace/project"
-    run_id = str(uuid.uuid4())
-
-    # and
-    family = "a" * 1000
-
-    # when
-    with pytest.raises(ValueError):
-        with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled"):
-            ...
-
-    # and
-    assert True
-
-
 def test_run_id_too_long(api_token):
     # given
     project = "workspace/project"
-    family = str(uuid.uuid4())
 
     # and
     run_id = "a" * 1000
 
     # then
     with pytest.raises(ValueError):
-        with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled"):
+        with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled"):
             ...
 
     # and
@@ -104,14 +83,13 @@ def test_run_id_too_long(api_token):
 def test_invalid_project_name(api_token):
     # given
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # and
     project = "just-project"
 
     # then
     with pytest.raises(ValueError):
-        with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled"):
+        with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled"):
             ...
 
     # and
@@ -122,10 +100,9 @@ def test_metadata(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.log(
             step=1,
             timestamp=datetime.now(),
@@ -156,10 +133,9 @@ def test_tags(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.add_tags(["tag1"])
         run.add_tags(["tag2"], group_tags=True)
         run.remove_tags(["tag3"])
@@ -173,10 +149,9 @@ def test_log_without_step(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.log(
             timestamp=datetime.now(),
             configs={
@@ -192,10 +167,9 @@ def test_log_configs(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.log_configs({"int": 1})
 
     # and
@@ -206,10 +180,9 @@ def test_log_step_float(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.log(
             step=3.14,
             timestamp=datetime.now(),
@@ -226,10 +199,9 @@ def test_log_no_timestamp(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # then
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, mode="disabled") as run:
         run.log(
             step=3.14,
             configs={
@@ -245,10 +217,9 @@ def test_resume(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # when
-    with Run(project=project, api_token=api_token, family=family, run_id=run_id, resume=True, mode="disabled") as run:
+    with Run(project=project, api_token=api_token, run_id=run_id, resume=True, mode="disabled") as run:
         run.log(
             step=3.14,
             configs={
@@ -265,13 +236,11 @@ def test_creation_time(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # when
     with Run(
         project=project,
         api_token=api_token,
-        family=family,
         run_id=run_id,
         creation_time=datetime.now(),
         mode="disabled",
@@ -286,13 +255,11 @@ def test_assign_experiment(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # when
     with Run(
         project=project,
         api_token=api_token,
-        family=family,
         run_id=run_id,
         experiment_name="experiment_id",
         mode="disabled",
@@ -307,13 +274,11 @@ def test_forking(api_token):
     # given
     project = "workspace/project"
     run_id = str(uuid.uuid4())
-    family = run_id
 
     # when
     with Run(
         project=project,
         api_token=api_token,
-        family=family,
         run_id=run_id,
         fork_run_id="parent-run-id",
         fork_step=3.14,


### PR DESCRIPTION
The `family` parameter should not be exposed to the user, as its purpose is strictly internal. This PR:

* removes the `family` parameter from `Run.__init__()`. This is a breaking change.
* passes `run_id` as `family` in all HTTP API requests.
