### PR TITLE
Change the logger's configuration to be more resilient

### DIFF
--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -43,7 +43,10 @@ from neptune_scale.core.components.errors_tracking import (
 from neptune_scale.core.components.lag_tracking import LagTracker
 from neptune_scale.core.components.operations_queue import OperationsQueue
 from neptune_scale.core.components.sync_process import SyncProcess
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import (
+    get_logger,
+    init_root_logger,
+)
 from neptune_scale.core.metadata_splitter import MetadataSplitter
 from neptune_scale.core.serialization import (
     datetime_to_proto,
@@ -73,6 +76,8 @@ from neptune_scale.parameters import (
     MINIMAL_WAIT_FOR_PUT_SLEEP_TIME,
     STOP_MESSAGE_FREQUENCY,
 )
+
+logger = get_logger()
 
 
 class Run(WithResources, AbstractContextManager):
@@ -126,6 +131,8 @@ class Run(WithResources, AbstractContextManager):
                 wasn't caught by other callbacks.
             on_warning_callback: Callback function triggered when a warning occurs.
         """
+
+        _, self._logging_queue = init_root_logger()
 
         verify_type("run_id", run_id, str)
         verify_type("resume", resume, bool)
@@ -224,6 +231,7 @@ class Run(WithResources, AbstractContextManager):
             family=self._run_id,
             operations_queue=self._operations_queue.queue,
             errors_queue=self._errors_queue,
+            logging_queue=self._logging_queue,
             api_token=input_api_token,
             last_put_seq=self._last_put_seq,
             last_put_seq_wait=self._last_put_seq_wait,

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -45,7 +45,7 @@ from neptune_scale.core.components.operations_queue import OperationsQueue
 from neptune_scale.core.components.sync_process import SyncProcess
 from neptune_scale.core.logger import (
     get_logger,
-    init_root_logger,
+    init_main_process_logger,
 )
 from neptune_scale.core.metadata_splitter import MetadataSplitter
 from neptune_scale.core.serialization import (
@@ -132,7 +132,7 @@ class Run(WithResources, AbstractContextManager):
             on_warning_callback: Callback function triggered when a warning occurs.
         """
 
-        _, self._logging_queue = init_root_logger()
+        _, self._logging_queue = init_main_process_logger()
 
         verify_type("run_id", run_id, str)
         verify_type("resume", resume, bool)

--- a/src/neptune_scale/api/api_client.py
+++ b/src/neptune_scale/api/api_client.py
@@ -55,9 +55,11 @@ from neptune_api.proto.neptune_pb.ingest.v1.pub.request_status_pb2 import Reques
 from neptune_api.types import Response
 
 from neptune_scale.core.components.abstract import Resource
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import get_logger
 from neptune_scale.envs import ALLOW_SELF_SIGNED_CERTIFICATE
 from neptune_scale.parameters import REQUEST_TIMEOUT
+
+logger = get_logger()
 
 
 @dataclass

--- a/src/neptune_scale/core/components/aggregating_queue.py
+++ b/src/neptune_scale/core/components/aggregating_queue.py
@@ -17,12 +17,14 @@ from neptune_scale.core.components.queue_element import (
     BatchedOperations,
     SingleOperation,
 )
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import get_logger
 from neptune_scale.parameters import (
     BATCH_WAIT_TIME_SECONDS,
     MAX_BATCH_SIZE,
     MAX_QUEUE_ELEMENT_SIZE,
 )
+
+logger = get_logger()
 
 
 class AggregatingQueue(Resource):

--- a/src/neptune_scale/core/components/daemon.py
+++ b/src/neptune_scale/core/components/daemon.py
@@ -4,7 +4,9 @@ import abc
 import threading
 from enum import Enum
 
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import get_logger
+
+logger = get_logger()
 
 
 class Daemon(threading.Thread):

--- a/src/neptune_scale/core/components/errors_tracking.py
+++ b/src/neptune_scale/core/components/errors_tracking.py
@@ -13,7 +13,7 @@ from typing import (
 
 from neptune_scale.core.components.abstract import Resource
 from neptune_scale.core.components.daemon import Daemon
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import get_logger
 from neptune_scale.core.process_killer import kill_me
 from neptune_scale.exceptions import (
     NeptuneAsyncLagThresholdExceeded,
@@ -24,6 +24,8 @@ from neptune_scale.exceptions import (
     NeptuneUnexpectedError,
 )
 from neptune_scale.parameters import ERRORS_MONITOR_THREAD_SLEEP_TIME
+
+logger = get_logger()
 
 
 class ErrorsQueue(Resource):

--- a/src/neptune_scale/core/components/operations_queue.py
+++ b/src/neptune_scale/core/components/operations_queue.py
@@ -11,7 +11,7 @@ from typing import (
 
 from neptune_scale.core.components.abstract import Resource
 from neptune_scale.core.components.queue_element import SingleOperation
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import get_logger
 from neptune_scale.core.validation import verify_type
 from neptune_scale.parameters import (
     MAX_MULTIPROCESSING_QUEUE_SIZE,
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from threading import RLock
 
     from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
+
+logger = get_logger()
 
 
 class OperationsQueue(Resource):

--- a/src/neptune_scale/core/components/sync_process.py
+++ b/src/neptune_scale/core/components/sync_process.py
@@ -60,7 +60,7 @@ from neptune_scale.core.components.queue_element import (
 )
 from neptune_scale.core.logger import (
     get_logger,
-    init_child_logger,
+    init_child_process_logger,
 )
 from neptune_scale.core.util import safe_signal_name
 from neptune_scale.exceptions import (
@@ -234,7 +234,7 @@ class SyncProcess(Process):
         self._stop_event.set()  # Trigger the stop event
 
     def run(self) -> None:
-        init_child_logger(self._logging_queue)
+        init_child_process_logger(self._logging_queue)
 
         logger.info("Data synchronization started")
 

--- a/src/neptune_scale/core/components/sync_process.py
+++ b/src/neptune_scale/core/components/sync_process.py
@@ -58,7 +58,10 @@ from neptune_scale.core.components.queue_element import (
     BatchedOperations,
     SingleOperation,
 )
-from neptune_scale.core.logger import logger
+from neptune_scale.core.logger import (
+    get_logger,
+    init_child_logger,
+)
 from neptune_scale.core.util import safe_signal_name
 from neptune_scale.exceptions import (
     NeptuneConnectionLostError,
@@ -105,6 +108,7 @@ from neptune_scale.parameters import (
 
 T = TypeVar("T")
 
+logger = get_logger()
 
 CODE_TO_ERROR: Dict[IngestCode.ValueType, Optional[Type[Exception]]] = {
     IngestCode.OK: None,
@@ -192,6 +196,7 @@ class SyncProcess(Process):
         self,
         operations_queue: Queue,
         errors_queue: ErrorsQueue,
+        logging_queue: Queue,
         api_token: str,
         project: str,
         family: str,
@@ -208,6 +213,7 @@ class SyncProcess(Process):
 
         self._external_operations_queue: Queue[SingleOperation] = operations_queue
         self._errors_queue: ErrorsQueue = errors_queue
+        self._logging_queue: Queue = logging_queue
         self._api_token: str = api_token
         self._project: str = project
         self._family: str = family
@@ -228,6 +234,8 @@ class SyncProcess(Process):
         self._stop_event.set()  # Trigger the stop event
 
     def run(self) -> None:
+        init_child_logger(self._logging_queue)
+
         logger.info("Data synchronization started")
 
         # Register signals handlers

--- a/src/neptune_scale/core/logger.py
+++ b/src/neptune_scale/core/logger.py
@@ -1,6 +1,6 @@
 __all__ = (
-    "init_root_logger",
-    "init_child_logger",
+    "init_main_process_logger",
+    "init_child_process_logger",
     "get_logger",
 )
 
@@ -34,7 +34,7 @@ def get_logger() -> logging.Logger:
     return logging.getLogger(NEPTUNE_LOGGER_NAME)
 
 
-def init_root_logger() -> Tuple[logging.Logger, multiprocessing.Queue]:
+def init_main_process_logger() -> Tuple[logging.Logger, multiprocessing.Queue]:
     """
     Initialize the root 'neptune' logger to use a mp.Queue. This should be called only once in the main process.
 
@@ -85,7 +85,7 @@ def init_root_logger() -> Tuple[logging.Logger, multiprocessing.Queue]:
     return logger, queue
 
 
-def init_child_logger(queue: multiprocessing.Queue) -> logging.Logger:
+def init_child_process_logger(queue: multiprocessing.Queue) -> logging.Logger:
     """
     Initialize a child logger to use the given queue. This should be called in child processes only once.
     After it's called, the logger can be retrieved using `get_logger()`.
@@ -96,6 +96,9 @@ def init_child_logger(queue: multiprocessing.Queue) -> logging.Logger:
     Returns:
         A logger instance.
     """
+
+    if multiprocessing.parent_process() is None:
+        raise RuntimeError("This function should be called only in child processes.")
 
     logger = logging.getLogger(NEPTUNE_LOGGER_NAME)
     if logger.hasHandlers():

--- a/src/neptune_scale/core/logger.py
+++ b/src/neptune_scale/core/logger.py
@@ -1,7 +1,21 @@
-__all__ = ("logger",)
+__all__ = (
+    "init_root_logger",
+    "init_child_logger",
+    "get_logger",
+)
 
+import atexit
 import logging
+import multiprocessing
 import os
+from logging.handlers import (
+    QueueHandler,
+    QueueListener,
+)
+from typing import (
+    List,
+    Tuple,
+)
 
 from neptune_scale.core.styles import (
     STYLES,
@@ -16,25 +30,90 @@ DEBUG_FORMAT = "%(asctime)s :: %(name)s :: %(levelname)s :: %(processName)s(%(pr
 
 
 def get_logger() -> logging.Logger:
+    """Use in modules to get the root Neptune logger"""
+    return logging.getLogger(NEPTUNE_LOGGER_NAME)
+
+
+def init_root_logger() -> Tuple[logging.Logger, multiprocessing.Queue]:
+    """
+    Initialize the root 'neptune' logger to use a mp.Queue. This should be called only once in the main process.
+
+    Returns:
+        A 2-tuple of (logger, queue). Queue should be passed to `init_child_logger()` in child processes.
+    """
+
+    if multiprocessing.parent_process() is not None:
+        raise RuntimeError("This function should be called only in the main process.")
+
+    logger = logging.getLogger(NEPTUNE_LOGGER_NAME)
+
+    # If the user has also imported `neptune-fetcher` the root logger will already be initialized.
+    # We want our handlers to take precedence. We will remove all handlers and add our own.
+    if logger.hasHandlers():
+        # Not initialized by us, clear handlers and proceed.
+        if not hasattr(logger, "__neptune_scale_listener"):
+            logger.handlers.clear()
+        else:
+            return logger, _get_queue_from_handlers(logger.handlers)
+
+    logger.setLevel(logging.INFO)
     ensure_style_detected()
 
-    neptune_logger = logging.getLogger(NEPTUNE_LOGGER_NAME)
-    neptune_logger.setLevel(logging.INFO)
-
+    handlers: List[logging.Handler] = []
     if os.environ.get(DEBUG_MODE, "False").lower() in ("true", "1"):
-        neptune_logger.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
         file_handler = logging.FileHandler(NEPTUNE_DEBUG_FILE_NAME)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(logging.Formatter(DEBUG_FORMAT))
-        neptune_logger.addHandler(file_handler)
+        handlers.append(file_handler)
 
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.INFO)
     stream_handler.setFormatter(logging.Formatter(LOG_FORMAT.format(**STYLES)))
-    neptune_logger.addHandler(stream_handler)
+    handlers.append(stream_handler)
 
-    return neptune_logger
+    queue: multiprocessing.Queue = multiprocessing.Queue()
+    logger.addHandler(QueueHandler(queue))
+
+    listener = QueueListener(queue, *handlers, respect_handler_level=True)
+    listener.start()
+
+    logger.__neptune_scale_listener = listener  # type: ignore
+    atexit.register(listener.stop)
+
+    return logger, queue
 
 
-logger = get_logger()
+def init_child_logger(queue: multiprocessing.Queue) -> logging.Logger:
+    """
+    Initialize a child logger to use the given queue. This should be called in child processes only once.
+    After it's called, the logger can be retrieved using `get_logger()`.
+
+    Args:
+        queue: A multiprocessing.Queue object returned by `init_root_logger()`.
+
+    Returns:
+        A logger instance.
+    """
+
+    logger = logging.getLogger(NEPTUNE_LOGGER_NAME)
+    if logger.hasHandlers():
+        # Make sure the QueueHandler is already registered
+        _ = _get_queue_from_handlers(logger.handlers)
+        return logger
+
+    ensure_style_detected()
+
+    logger.addHandler(QueueHandler(queue))
+    logger.setLevel(logging.INFO)
+
+    return logger
+
+
+def _get_queue_from_handlers(handlers: List[logging.Handler]) -> multiprocessing.Queue:
+    for h in handlers:
+        if isinstance(h, QueueHandler):
+            return h.queue  # type: ignore # mypy doesn't know it's always Queue
+
+    raise RuntimeError("Expected to find a QueueHandler in the logger handlers.")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,50 @@
+from concurrent.futures.process import ProcessPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+
+from neptune_scale.core.logger import (
+    get_logger,
+    init_child_process_logger,
+    init_main_process_logger,
+)
+
+
+def test_multiple_initialization_in_main_process():
+    logger, queue = init_main_process_logger()
+
+    # Keep a copy of handlers to make sure they're not modified once the logger is initialized.
+    handlers = logger.handlers[:]
+    _, queue2 = init_main_process_logger()
+
+    assert queue is queue2
+    assert get_logger().handlers == handlers
+
+
+def test_restrict_main_process_initialization_to_main_process():
+    with ProcessPoolExecutor() as executor, pytest.raises(RuntimeError) as err:
+        executor.submit(init_main_process_logger).result()
+
+    err.match("only in the main process")
+
+
+def test_restrict_child_process_initialization_to_child_process():
+    with pytest.raises(RuntimeError) as err:
+        init_child_process_logger(Mock())
+
+    err.match("only in child process")
+
+
+def _child():
+    logger = init_child_process_logger(Mock())
+
+    # Keep a copy of handlers to make sure they're not modified once the logger is initialized.
+    handlers = logger.handlers[:]
+    init_child_process_logger(Mock())
+
+    assert get_logger().handlers == handlers
+
+
+def test_multiple_initialization_in_child_process():
+    with ProcessPoolExecutor() as executor:
+        executor.submit(_child).result()


### PR DESCRIPTION
Previously we configured loggers separately in multiple processes. This caused problems with logging to files and exceptions about closed filedescriptors appearing randomly from time to time.

The core part is having separate initialization methods for main and child processes, and passing a shared `multiprocessing.Queue`, which is used for logging, to `SyncProcess`.

Summary of the changes:

- Use `QueueHandler` in child processes, paired with `QueueListener` in the main process
- Make sure initializing multiple Runs in a single process does not break the logger
- Make sure importing other neptune libs (like neptune-fetcher) does not break logging
