### PR TITLE
Convert naive `datetime` objects to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ You can log configurations or other single values. Pass the metadata as a dictio
 
 For example, `{"parameters/learning_rate": 0.001}`. In the field path, each forward slash `/` nests the field under a namespace. Use namespaces to structure the metadata into meaningful categories.
 
+Any `datetime` values that don't have the `tzinfo` attribute set are assumed to be in the local timezone.
+
 __Parameters__
 
 | Name          | Type                                               | Default | Description                                                               |
@@ -265,7 +267,7 @@ __Parameters__
 |-------------|------------------------------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `data`      | `Dict[str, Union[float, int]]` | `None`  | Dictionary of metrics to log. Each metric value is associated with a step. To log multiple metrics at once, pass multiple key-value pairs.                                                                                                                           |
 | `step`      | `Union[float, int]`           | `None`  | Index of the log entry. Must be increasing. <br> **Tip:** Using float rather than int values can be useful, for example, when logging substeps in a batch. |
-| `timestamp` | `datetime`, optional                     | `None`  | Time of logging the metadata.                                                                                                                                                                                                                                        |
+| `timestamp` | `datetime`, optional                     | `None`  | Time of logging the metadata. If not provided, the current time is used. If provided, and `timestamp.tzinfo` is not set, the time is assumed to be in the local timezone.                                                                                            |
 
 __Examples__
 

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -568,7 +568,7 @@ class Run(WithResources, AbstractContextManager):
             run_id=self._run_id,
             step=step,
             timestamp=timestamp,
-            fields=configs,
+            configs=configs,
             metrics=metrics,
             add_tags=tags_add,
             remove_tags=tags_remove,

--- a/src/neptune_scale/core/metadata_splitter.py
+++ b/src/neptune_scale/core/metadata_splitter.py
@@ -43,7 +43,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         run_id: str,
         step: Optional[Union[int, float]],
         timestamp: datetime,
-        fields: Dict[str, Union[float, bool, int, str, datetime]],
+        configs: Dict[str, Union[float, bool, int, str, datetime]],
         metrics: Dict[str, float],
         add_tags: Dict[str, Union[List[str], Set[str]]],
         remove_tags: Dict[str, Union[List[str], Set[str]]],
@@ -53,7 +53,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         self._timestamp = datetime_to_proto(timestamp)
         self._project = project
         self._run_id = run_id
-        self._fields = peekable(fields.items())
+        self._configs = peekable(configs.items())
         self._metrics = peekable(starmap(lambda k, v: (k, float(v)), metrics.items()))
         self._add_tags = peekable(add_tags.items())
         self._remove_tags = peekable(remove_tags.items())
@@ -84,7 +84,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         size = update.ByteSize()
 
         size = self.populate(
-            assets=self._fields,
+            assets=self._configs,
             update_producer=lambda key, value: update.assign[key].MergeFrom(value),
             size=size,
         )

--- a/src/neptune_scale/core/serialization.py
+++ b/src/neptune_scale/core/serialization.py
@@ -21,6 +21,8 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
     Value,
 )
 
+from .util import ensure_utc
+
 
 def make_value(value: Union[Value, float, str, int, bool, datetime, List[str], Set[str]]) -> Value:
     if isinstance(value, Value):
@@ -43,7 +45,7 @@ def make_value(value: Union[Value, float, str, int, bool, datetime, List[str], S
 
 
 def datetime_to_proto(dt: datetime) -> Timestamp:
-    dt_ts = dt.timestamp()
+    dt_ts = ensure_utc(dt).timestamp()
     return Timestamp(seconds=int(dt_ts), nanos=int((dt_ts % 1) * 1e9))
 
 

--- a/src/neptune_scale/core/util.py
+++ b/src/neptune_scale/core/util.py
@@ -1,4 +1,8 @@
 import signal
+from datetime import (
+    datetime,
+    timezone,
+)
 
 
 def safe_signal_name(signum: int) -> str:
@@ -8,3 +12,12 @@ def safe_signal_name(signum: int) -> str:
         signame = str(signum)
 
     return signame
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    """If `dt` has no TZ info, assume it's local time, and convert to UTC. Otherwise return as is."""
+
+    if dt.tzinfo is None:
+        return dt.astimezone(timezone.utc)
+
+    return dt

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -24,7 +24,7 @@ def test_empty():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={},
         add_tags={},
         remove_tags={},
@@ -51,7 +51,7 @@ def test_fields():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={
+        configs={
             "some/string": "value",
             "some/int": 2501,
             "some/float": 3.14,
@@ -95,7 +95,7 @@ def test_metrics():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={
             "some/metric": 3.14,
         },
@@ -129,7 +129,7 @@ def test_tags():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={},
         add_tags={
             "some/tags": {"tag1", "tag2"},
@@ -186,7 +186,7 @@ def test_splitting():
         run_id="run_id",
         step=1,
         timestamp=timestamp,
-        fields=fields,
+        configs=fields,
         metrics=metrics,
         add_tags=add_tags,
         remove_tags=remove_tags,
@@ -232,7 +232,7 @@ def test_split_large_tags():
         run_id="run_id",
         step=1,
         timestamp=timestamp,
-        fields=fields,
+        configs=fields,
         metrics=metrics,
         add_tags=add_tags,
         remove_tags=remove_tags,

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -1,4 +1,7 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timezone,
+)
 
 from freezegun import freeze_time
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -23,7 +26,7 @@ def test_empty():
         project="workspace/project",
         run_id="run_id",
         step=1,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         configs={},
         metrics={},
         add_tags={},
@@ -50,13 +53,13 @@ def test_fields():
         project="workspace/project",
         run_id="run_id",
         step=1,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         configs={
             "some/string": "value",
             "some/int": 2501,
             "some/float": 3.14,
             "some/bool": True,
-            "some/datetime": datetime.now(),
+            "some/datetime": datetime.now(timezone.utc),
             "some/tags": {"tag1", "tag2"},
         },
         metrics={},
@@ -94,7 +97,7 @@ def test_metrics():
         project="workspace/project",
         run_id="run_id",
         step=1,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         configs={},
         metrics={
             "some/metric": 3.14,
@@ -128,7 +131,7 @@ def test_tags():
         project="workspace/project",
         run_id="run_id",
         step=1,
-        timestamp=datetime.now(),
+        timestamp=datetime.now(timezone.utc),
         configs={},
         metrics={},
         add_tags={
@@ -174,7 +177,7 @@ def test_tags():
 def test_splitting():
     # given
     max_size = 1024
-    timestamp = datetime.now()
+    timestamp = datetime.now(timezone.utc)
     metrics = {f"metric{v}": 7 / 9.0 * v for v in range(1000)}
     fields = {f"field{v}": v for v in range(1000)}
     add_tags = {f"add/tag{v}": {f"value{v}"} for v in range(1000)}
@@ -220,7 +223,7 @@ def test_splitting():
 def test_split_large_tags():
     # given
     max_size = 1024
-    timestamp = datetime.now()
+    timestamp = datetime.now(timezone.utc)
     metrics = {}
     fields = {}
     add_tags = {"add/tag": {f"value{v}" for v in range(1000)}}


### PR DESCRIPTION
Assume that if `tzinfo` is not provided, the `datetime` object is in local timezone, and convert it to UTC.

Previously we would log `datetimes` as local timestamp, which resulted in incorrect data.