### PR TITLE
Rename `MetadataSplitter._fields` -> `_configs`

### DIFF
--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -573,7 +573,7 @@ class Run(WithResources, AbstractContextManager):
             run_id=self._run_id,
             step=step,
             timestamp=timestamp,
-            fields=configs,
+            configs=configs,
             metrics=metrics,
             add_tags=tags_add,
             remove_tags=tags_remove,

--- a/src/neptune_scale/core/metadata_splitter.py
+++ b/src/neptune_scale/core/metadata_splitter.py
@@ -43,7 +43,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         run_id: str,
         step: Optional[Union[int, float]],
         timestamp: datetime,
-        fields: Dict[str, Union[float, bool, int, str, datetime, list, set, tuple]],
+        configs: Dict[str, Union[float, bool, int, str, datetime, list, set, tuple]],
         metrics: Dict[str, float],
         add_tags: Dict[str, Union[List[str], Set[str], Tuple[str]]],
         remove_tags: Dict[str, Union[List[str], Set[str], Tuple[str]]],
@@ -53,7 +53,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         self._timestamp = datetime_to_proto(timestamp)
         self._project = project
         self._run_id = run_id
-        self._fields = peekable(fields.items())
+        self._configs = peekable(configs.items())
         self._metrics = peekable(starmap(lambda k, v: (k, float(v)), metrics.items()))
         self._add_tags = peekable(add_tags.items())
         self._remove_tags = peekable(remove_tags.items())
@@ -84,7 +84,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         size = update.ByteSize()
 
         size = self.populate(
-            assets=self._fields,
+            assets=self._configs,
             update_producer=lambda key, value: update.assign[key].MergeFrom(value),
             size=size,
         )

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -24,7 +24,7 @@ def test_empty():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={},
         add_tags={},
         remove_tags={},
@@ -51,7 +51,7 @@ def test_fields():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={
+        configs={
             "some/string": "value",
             "some/int": 2501,
             "some/float": 3.14,
@@ -95,7 +95,7 @@ def test_metrics():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={
             "some/metric": 3.14,
         },
@@ -129,7 +129,7 @@ def test_tags():
         run_id="run_id",
         step=1,
         timestamp=datetime.now(),
-        fields={},
+        configs={},
         metrics={},
         add_tags={
             "some/tags": {"tag1", "tag2"},
@@ -186,7 +186,7 @@ def test_splitting():
         run_id="run_id",
         step=1,
         timestamp=timestamp,
-        fields=fields,
+        configs=fields,
         metrics=metrics,
         add_tags=add_tags,
         remove_tags=remove_tags,
@@ -232,7 +232,7 @@ def test_split_large_tags():
         run_id="run_id",
         step=1,
         timestamp=timestamp,
-        fields=fields,
+        configs=fields,
         metrics=metrics,
         add_tags=add_tags,
         remove_tags=remove_tags,


### PR DESCRIPTION
This is more consistent with naming across the project