### PR TITLE
Add `SharedVar` class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,29 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-illegal-windows-names
+      - id: check-merge-conflict
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
-        args: [--settings-path, pyproject.toml]
+        args: [ --settings-path, pyproject.toml ]
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.10.0
     hooks:
       - id: black
-        args: [--config, pyproject.toml]
+        args: [ --config, pyproject.toml ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.9
+    rev: v0.7.2
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.13.0
     hooks:
       - id: mypy
         args: [ --config-file, pyproject.toml ]
@@ -31,4 +33,4 @@ repos:
           - more-itertools
           - backoff
 default_language_version:
-    python: python3
+  python: python3

--- a/src/neptune_scale/core/components/lag_tracking.py
+++ b/src/neptune_scale/core/components/lag_tracking.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 __all__ = ("LagTracker",)
 
-from multiprocessing.sharedctypes import Synchronized
-from multiprocessing.synchronize import Condition
 from time import monotonic
 from typing import Callable
 
@@ -11,6 +9,7 @@ from neptune_scale.core.components.abstract import Resource
 from neptune_scale.core.components.daemon import Daemon
 from neptune_scale.core.components.errors_tracking import ErrorsQueue
 from neptune_scale.core.components.operations_queue import OperationsQueue
+from neptune_scale.core.shared_var import SharedFloat
 from neptune_scale.parameters import (
     LAG_TRACKER_THREAD_SLEEP_TIME,
     LAG_TRACKER_TIMEOUT,
@@ -22,8 +21,7 @@ class LagTracker(Daemon, Resource):
         self,
         errors_queue: ErrorsQueue,
         operations_queue: OperationsQueue,
-        last_ack_timestamp: Synchronized[float],
-        last_ack_timestamp_wait: Condition,
+        last_ack_timestamp: SharedFloat,
         async_lag_threshold: float,
         on_async_lag_callback: Callable[[], None],
     ) -> None:
@@ -31,26 +29,25 @@ class LagTracker(Daemon, Resource):
 
         self._errors_queue: ErrorsQueue = errors_queue
         self._operations_queue: OperationsQueue = operations_queue
-        self._last_ack_timestamp: Synchronized[float] = last_ack_timestamp
-        self._last_ack_timestamp_wait: Condition = last_ack_timestamp_wait
+        self._last_ack_timestamp: SharedFloat = last_ack_timestamp
         self._async_lag_threshold: float = async_lag_threshold
         self._on_async_lag_callback: Callable[[], None] = on_async_lag_callback
 
         self._callback_triggered: bool = False
 
     def work(self) -> None:
-        with self._last_ack_timestamp_wait:
-            self._last_ack_timestamp_wait.wait(timeout=LAG_TRACKER_TIMEOUT)
+        with self._last_ack_timestamp:
+            self._last_ack_timestamp.wait(timeout=LAG_TRACKER_TIMEOUT)
             last_ack_timestamp = self._last_ack_timestamp.value
-            last_put_timestamp = self._operations_queue.last_timestamp
+            last_queued_timestamp = self._operations_queue.last_timestamp
 
             # No operations were put into the queue
-            if last_put_timestamp is None:
+            if last_queued_timestamp is None:
                 return
 
             # No operations were processed by server
             if last_ack_timestamp < 0 and not self._callback_triggered:
-                if monotonic() - last_put_timestamp > self._async_lag_threshold:
+                if monotonic() - last_queued_timestamp > self._async_lag_threshold:
                     self._callback_triggered = True
                     self._on_async_lag_callback()
                     return
@@ -58,7 +55,7 @@ class LagTracker(Daemon, Resource):
                 self._callback_triggered = False
             else:
                 # Some operations were processed by server
-                if last_put_timestamp - last_ack_timestamp > self._async_lag_threshold:
+                if last_queued_timestamp - last_ack_timestamp > self._async_lag_threshold:
                     if not self._callback_triggered:
                         self._callback_triggered = True
                         self._on_async_lag_callback()

--- a/src/neptune_scale/core/shared_var.py
+++ b/src/neptune_scale/core/shared_var.py
@@ -1,12 +1,12 @@
 import multiprocessing
 from types import TracebackType
 from typing import (
-    Any,
     Callable,
     Generic,
     Optional,
     Type,
     TypeVar,
+    cast,
 )
 
 __all__ = ("SharedInt", "SharedFloat", "SharedVar")
@@ -39,9 +39,9 @@ class SharedVar(Generic[T]):
         self._condition = multiprocessing.Condition(self._value.get_lock())
 
     @property
-    def value(self) -> Any:
+    def value(self) -> T:
         with self._condition:
-            return self._value.value
+            return cast(T, self._value.value)
 
     @value.setter
     def value(self, new_value: T) -> None:

--- a/src/neptune_scale/core/shared_var.py
+++ b/src/neptune_scale/core/shared_var.py
@@ -1,0 +1,83 @@
+import multiprocessing
+from types import TracebackType
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+__all__ = ("SharedInt", "SharedFloat", "SharedVar")
+
+T = TypeVar("T", int, float)
+
+
+class SharedVar(Generic[T]):
+    """A convenience wrapper around multiprocessing.Value and multiprocessing.Condition.
+
+    Access the Value using the `value` property. Other methods, as well as context management
+    delegate to the Condition object.
+
+    Typical usage:
+        var = SharedInt(0)
+
+        # In one process
+        with var:
+            var.value += 1
+            var.notify() # Notify the waiting process
+
+        # In another process
+        with var:
+            var.wait() # Wait until the value is changed
+            print(var.value)
+    """
+
+    def __init__(self, typecode_or_type: str, initial_value: T):
+        self._value = multiprocessing.Value(typecode_or_type, initial_value)
+        self._condition = multiprocessing.Condition(self._value.get_lock())
+
+    @property
+    def value(self) -> Any:
+        with self._condition:
+            return self._value.value
+
+    @value.setter
+    def value(self, new_value: T) -> None:
+        with self._condition:
+            self._value.value = new_value
+
+    def wait(self, timeout: Optional[float] = None) -> None:
+        with self._condition:
+            self._condition.wait(timeout)
+
+    def wait_for(self, predicate: Callable[[], bool], timeout: Optional[float] = None) -> None:
+        with self._condition:
+            self._condition.wait_for(predicate, timeout)
+
+    def notify_all(self) -> None:
+        with self._condition:
+            self._condition.notify_all()
+
+    def __enter__(self) -> "SharedVar[T]":
+        self._condition.__enter__()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self._condition.__exit__(exc_type, exc_value, traceback)
+
+
+class SharedInt(SharedVar[int]):
+    def __init__(self, initial_value: int) -> None:
+        super().__init__("i", initial_value)
+
+
+class SharedFloat(SharedVar[float]):
+    def __init__(self, initial_value: float) -> None:
+        super().__init__("d", initial_value)

--- a/tests/unit/test_lag_tracker.py
+++ b/tests/unit/test_lag_tracker.py
@@ -1,10 +1,10 @@
-import multiprocessing
 import time
 from threading import Event
 from unittest.mock import Mock
 
 from freezegun import freeze_time
 
+from neptune_scale import SharedFloat
 from neptune_scale.core.components.lag_tracking import LagTracker
 
 
@@ -17,8 +17,7 @@ def test__lag_tracker__callback_called():
     # and
     errors_queue = Mock()
     operations_queue = Mock(last_timestamp=time.time())
-    last_ack_timestamp = multiprocessing.Value("d", time.time() - lag)
-    last_ack_timestamp_wait = multiprocessing.Condition()
+    last_ack_timestamp = SharedFloat(time.time() - lag)
     callback = Mock()
 
     # Synchronization event
@@ -34,7 +33,6 @@ def test__lag_tracker__callback_called():
         errors_queue=errors_queue,
         operations_queue=operations_queue,
         last_ack_timestamp=last_ack_timestamp,
-        last_ack_timestamp_wait=last_ack_timestamp_wait,
         async_lag_threshold=async_lag_threshold,
         on_async_lag_callback=callback_with_event,
     )
@@ -63,8 +61,7 @@ def test__lag_tracker__not_called():
     # and
     errors_queue = Mock()
     operations_queue = Mock(last_timestamp=time.time())
-    last_ack_timestamp = multiprocessing.Value("d", time.time() - lag)
-    last_ack_timestamp_wait = multiprocessing.Condition()
+    last_ack_timestamp = SharedFloat(time.time() - lag)
     callback = Mock()
 
     # and
@@ -72,7 +69,6 @@ def test__lag_tracker__not_called():
         errors_queue=errors_queue,
         operations_queue=operations_queue,
         last_ack_timestamp=last_ack_timestamp,
-        last_ack_timestamp_wait=last_ack_timestamp_wait,
         async_lag_threshold=async_lag_threshold,
         on_async_lag_callback=callback,
     )

--- a/tests/unit/test_shared_var.py
+++ b/tests/unit/test_shared_var.py
@@ -1,0 +1,37 @@
+from multiprocessing import Process
+
+import pytest
+
+from neptune_scale.core.shared_var import (
+    SharedFloat,
+    SharedInt,
+)
+
+
+def _child(var):
+    with var:
+        var.value = 1
+        var.notify_all()
+
+    var.wait(timeout=1)
+    assert var.value == 2
+
+
+@pytest.mark.parametrize("tp", (SharedInt, SharedFloat))
+def test_set_and_notify(tp):
+    var = tp(0)
+
+    process = Process(target=_child, args=(var,))
+    process.start()
+
+    var.wait(timeout=1)
+    assert var.value == 1
+
+    with var:
+        var.value = 2
+        var.notify_all()
+
+    process.join()
+
+    assert var.value == 2
+    assert process.exitcode == 0, "Child process failed"


### PR DESCRIPTION
Add `SharedVar` class.

This is a simple wrapper around `Value` and `Condition` from `multiprocessing` that increases readability and is more convenient to use.

Our typical usage pattern is changing the `Value` and notifying listeners on waiting `Condition`.  Instead of passing two separate values around, we now use a single instance of  `SharedInt` or`SharedFloat`.

In a gist, Instead of this:

```python
self._last_ack_seq: Synchronized[int] = multiprocessing.Value("i", -1)
self._last_ack_seq_wait: ConditionT = multiprocessing.Condition()
```

We have this:
```python
self._last_ack_seq = SharedInt(-1)
```

I'm also piggybacking an update to `pre-commit` configuration.