### PR TITLE
Remove `NeptuneFloatValueNanInfUnsupported`

### DIFF
--- a/src/neptune_scale/core/components/sync_process.py
+++ b/src/neptune_scale/core/components/sync_process.py
@@ -68,7 +68,6 @@ from neptune_scale.exceptions import (
     NeptuneFieldPathNonWritable,
     NeptuneFieldTypeConflicting,
     NeptuneFieldTypeUnsupported,
-    NeptuneFloatValueNanInfUnsupported,
     NeptuneInternalServerError,
     NeptuneInvalidCredentialsError,
     NeptuneOperationsQueueMaxSizeExceeded,
@@ -126,7 +125,6 @@ CODE_TO_ERROR: Dict[IngestCode.ValueType, Optional[Type[Exception]]] = {
     IngestCode.SERIES_STEP_NON_INCREASING: NeptuneSeriesStepNonIncreasing,
     IngestCode.SERIES_STEP_NOT_AFTER_FORK_POINT: NeptuneSeriesStepNotAfterForkPoint,
     IngestCode.SERIES_TIMESTAMP_DECREASING: NeptuneSeriesTimestampDecreasing,
-    IngestCode.FLOAT_VALUE_NAN_INF_UNSUPPORTED: NeptuneFloatValueNanInfUnsupported,
     IngestCode.STRING_VALUE_EXCEEDS_SIZE_LIMIT: NeptuneStringValueExceedsSizeLimit,
     IngestCode.STRING_SET_EXCEEDS_SIZE_LIMIT: NeptuneStringSetExceedsSizeLimit,
 }

--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -29,7 +29,6 @@ __all__ = (
     "NeptuneSeriesStepNonIncreasing",
     "NeptuneSeriesStepNotAfterForkPoint",
     "NeptuneSeriesTimestampDecreasing",
-    "NeptuneFloatValueNanInfUnsupported",
     "NeptuneStringValueExceedsSizeLimit",
     "NeptuneStringSetExceedsSizeLimit",
     "NeptuneSynchronizationStopped",
@@ -438,19 +437,6 @@ class NeptuneSeriesTimestampDecreasing(NeptuneScaleError):
 ----NeptuneSeriesTimestampDecreasing-------------------------------------------
 {end}
 The timestamp of a series value is less than the most recently logged value. Identical timestamps are allowed.
-
-{correct}Need help?{end}-> Contact support@neptune.ai
-
-Struggling with the formatting? To disable it, set the `NEPTUNE_DISABLE_COLORS` environment variable to `True`.
-"""
-
-
-class NeptuneFloatValueNanInfUnsupported(NeptuneScaleError):
-    message = """
-{h1}
-----NeptuneFloatValueNanInfUnsupported-----------------------------------------
-{end}
-Unsupported value type for float64 field or float64 series. Applies to Inf and NaN values.
 
 {correct}Need help?{end}-> Contact support@neptune.ai
 


### PR DESCRIPTION
It's not used anymore, as we support both NaN and Inf

FYI @normandy7 