### PR TITLE
Change "field" to "attribute" in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ You can log configurations or other single values. Pass the metadata as a dictio
 - `key`: path to where the metadata should be stored in the run.
 - `value`: the piece of metadata to log.
 
-For example, `{"parameters/learning_rate": 0.001}`. In the field path, each forward slash `/` nests the field under a namespace. Use namespaces to structure the metadata into meaningful categories.
+For example, `{"parameters/learning_rate": 0.001}`. In the attribute path, each forward slash `/` nests the attribute under a namespace. Use namespaces to structure the metadata into meaningful categories.
 
 Any `datetime` values that don't have the `tzinfo` attribute set are assumed to be in the local timezone.
 
@@ -259,7 +259,7 @@ You can log metrics representing a series of numeric values. Pass the metadata a
 - `key`: path to where the metadata should be stored in the run.
 - `value`: the piece of metadata to log.
 
-For example, `{"metrics/accuracy": 0.89}`. In the field path, each forward slash `/` nests the field under a namespace. Use namespaces to structure the metadata into meaningful categories.
+For example, `{"metrics/accuracy": 0.89}`. In the attribute path, each forward slash `/` nests the attribute under a namespace. Use namespaces to structure the metadata into meaningful categories.
 
 __Parameters__
 

--- a/src/neptune_scale/__init__.py
+++ b/src/neptune_scale/__init__.py
@@ -410,7 +410,7 @@ class Run(WithResources, AbstractContextManager):
         - value: a float or int value to append to the series.
 
         For example, {"metrics/accuracy": 0.89}.
-        In the field path, each forward slash "/" nests the field under a namespace.
+        In the attribute path, each forward slash "/" nests the attribute under a namespace.
         Use namespaces to structure the metadata into meaningful categories.
 
         Args:
@@ -448,7 +448,7 @@ class Run(WithResources, AbstractContextManager):
         - value: configuration or other single value to log.
 
         For example, {"parameters/learning_rate": 0.001}.
-        In the field path, each forward slash "/" nests the field under a namespace.
+        In the attribute path, each forward slash "/" nests the attribute under a namespace.
         Use namespaces to structure the metadata into meaningful categories.
 
         Args:


### PR DESCRIPTION
Change mentions of "field" to "attribute" in docstrings and other documentation.