### PR TITLE
Move the core logic from `Run.log()` to `AttributeStore`

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,7 @@
 -e .
 
 # dev
+black
 pre-commit
 pytest
 pytest-timeout

--- a/src/neptune_scale/api/attribute.py
+++ b/src/neptune_scale/api/attribute.py
@@ -7,7 +7,6 @@ from collections.abc import (
 )
 from datetime import datetime
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
@@ -15,8 +14,8 @@ from typing import (
     cast,
 )
 
-if TYPE_CHECKING:
-    from neptune_scale.api.run import Run
+from neptune_scale.sync.metadata_splitter import MetadataSplitter
+from neptune_scale.sync.operations_queue import OperationsQueue
 
 __all__ = ("Attribute", "AttributeStore")
 
@@ -44,12 +43,21 @@ def warn_unsupported_params(fn: Callable) -> Callable:
 
 
 # TODO: proper typehinting
+# AtomType = Union[float, bool, int, str, datetime, list, set, tuple]
 ValueType = Any  # Union[float, int, str, bool, datetime, Tuple, List, Dict, Set]
 
 
 class AttributeStore:
-    def __init__(self, run: "Run") -> None:
-        self._run = run
+    """
+    Responsible for managing local attribute store, and pushing log() operations
+    to the provided OperationsQueue -- assuming that there is something on the other
+    end consuming the queue (which would be SyncProcess).
+    """
+
+    def __init__(self, project: str, run_id: str, operations_queue: OperationsQueue) -> None:
+        self._project = project
+        self._run_id = run_id
+        self._operations_queue = operations_queue
         self._attributes: dict[str, Attribute] = {}
 
     def __getitem__(self, path: str) -> "Attribute":
@@ -62,7 +70,7 @@ class AttributeStore:
         return attr
 
     def __setitem__(self, key: str, value: ValueType) -> None:
-        # TODO: validate type if attr is already known
+        # TODO: validate type if attr is already known?
         attr = self[key]
         attr.assign(value)
 
@@ -75,31 +83,34 @@ class AttributeStore:
         tags_add: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
         tags_remove: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
     ) -> None:
-        # TODO: This should not call Run.log, but do the actual work. Reverse the current dependency so that this
-        #       class handles all the logging
-        timestamp = datetime.now() if timestamp is None else timestamp
+        if timestamp is None:
+            timestamp = datetime.now()
+        elif isinstance(timestamp, float):
+            timestamp = datetime.fromtimestamp(timestamp)
 
-        # TODO: Remove this and teach MetadataSplitter to handle Nones
-        configs = {} if configs is None else configs
-        metrics = {} if metrics is None else metrics
-        tags_add = {} if tags_add is None else tags_add
-        tags_remove = {} if tags_remove is None else tags_remove
-
-        # TODO: remove once Run.log accepts Union[datetime, float]
-        timestamp = cast(datetime, timestamp)
-        self._run.log(
-            step=step, timestamp=timestamp, configs=configs, metrics=metrics, tags_add=tags_add, tags_remove=tags_remove
+        splitter: MetadataSplitter = MetadataSplitter(
+            project=self._project,
+            run_id=self._run_id,
+            step=step,
+            timestamp=timestamp,
+            configs=configs,
+            metrics=metrics,
+            add_tags=tags_add,
+            remove_tags=tags_remove,
         )
+
+        for operation, metadata_size in splitter:
+            self._operations_queue.enqueue(operation=operation, size=metadata_size, key=step)
 
 
 class Attribute:
     """Objects of this class are returned on dict-like access to Run. Attributes have a path and
-    allow logging values under it.
+    allow logging values under it. Example:
 
-    run = Run(...)
-    run['foo'] = 1
-    run['nested'] = {'foo': 1, {'bar': {'baz': 2}}}
-    run['bar'].append(1, step=10)
+        run = Run(...)
+        run['foo'] = 1
+        run['nested'] = {'foo': 1, {'bar': {'baz': 2}}}
+        run['bar'].append(1, step=10)
     """
 
     def __init__(self, store: AttributeStore, path: str) -> None:
@@ -166,6 +177,67 @@ class Attribute:
     # TODO: change Run API to typehint timestamp as Union[datetime, float]
 
 
+def cleanup_path(path: str) -> str:
+    """
+    >>> cleanup_path('/a/b/c')
+    'a/b/c'
+    >>> cleanup_path('a/b/c/')
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid path: `a/b/c/`. Path must not end with a slash.
+    >>> cleanup_path('a//b/c')
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid path: `a//b/c`. Path components must not be empty.
+    >>> cleanup_path('a/ /b/c')
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid path: `a/ /b/c`. Path components must not be empty.
+    >>> cleanup_path('a/b/c ')
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid path: `a/b/c `. Path cannot contain leading or trailing whitespace.
+    """
+
+    if path.strip() in ("", "/"):
+        raise ValueError(f"Invalid path: `{path}`.")
+
+    if path.startswith("/"):
+        path = path[1:]
+
+    if path.endswith("/"):
+        raise ValueError(f"Invalid path: `{path}`. Path must not end with a slash.")
+
+    if not all(x.strip() for x in path.split("/")):
+        raise ValueError(f"Invalid path: `{path}`. Path components must not be empty.")
+
+    if path[0].lstrip() != path[0] or path[-1].rstrip() != path[-1]:
+        raise ValueError(f"Invalid path: `{path}`. Path cannot contain leading or trailing whitespace.")
+
+    return path
+
+
+def accumulate_dict_values(value: Union[ValueType, dict[str, ValueType]], path_or_base: str) -> dict[str, Any]:
+    """
+    If value is a dict, flatten nested dictionaries into a single dict with unwrapped paths, each
+    starting with `path_or_base`.
+
+    If value is an atom, return a dict with a single entry `path_or_base` -> `value`.
+
+    >>> accumulate_dict_values(1, "foo")
+    {'foo': 1}
+    >>> accumulate_dict_values({"bar": 1, 'l0/l1': 2, 'l3':{"l4": 3}}, "foo")
+    {'foo/bar': 1, 'foo/l0/l1': 2, 'foo/l3/l4': 3}
+    """
+
+    if isinstance(value, dict):
+        data = {"/".join(path): value for path, value in iter_nested(value, path_or_base)}
+    else:
+        data = {path_or_base: value}
+
+    return data
+
+
 def iter_nested(dict_: dict[str, ValueType], path: str) -> Iterator[tuple[tuple[str, ...], ValueType]]:
     """Iterate a nested dictionary, yielding a tuple of path components and value.
 
@@ -195,48 +267,3 @@ def _iter_nested(dict_: dict[str, ValueType], path_acc: tuple[str, ...]) -> Iter
             yield from _iter_nested(value, current_path)
         else:
             yield current_path, value
-
-
-def cleanup_path(path: str) -> str:
-    """
-    >>> cleanup_path('/a/b/c')
-    'a/b/c'
-    >>> cleanup_path('a/b/c/')
-    Traceback (most recent call last):
-    ...
-    ValueError: Invalid path: `a/b/c/`. Path must not end with a slash.
-    >>> cleanup_path('a//b/c')
-    Traceback (most recent call last):
-    ...
-    ValueError: Invalid path: `a//b/c`. Path components must not be empty.
-    """
-
-    path = path.strip()
-    if path in ("", "/"):
-        raise ValueError(f"Invalid path: `{path}`.")
-
-    if path.startswith("/"):
-        path = path[1:]
-
-    if path.endswith("/"):
-        raise ValueError(f"Invalid path: `{path}`. Path must not end with a slash.")
-    if not all(path.split("/")):
-        raise ValueError(f"Invalid path: `{path}`. Path components must not be empty.")
-
-    return path
-
-
-def accumulate_dict_values(value: Union[ValueType, dict[str, ValueType]], path_or_base: str) -> dict:
-    """
-    >>> accumulate_dict_values(1, "foo")
-    {'foo': 1}
-    >>> accumulate_dict_values({"bar": 1, 'l0/l1': 2, 'l3':{"l4": 3}}, "foo")
-    {'foo/bar': 1, 'foo/l0/l1': 2, 'foo/l3/l4': 3}
-    """
-
-    if isinstance(value, dict):
-        data = {"/".join(path): value for path, value in iter_nested(value, path_or_base)}
-    else:
-        data = {path_or_base: value}
-
-    return data

--- a/src/neptune_scale/api/attribute.py
+++ b/src/neptune_scale/api/attribute.py
@@ -192,29 +192,34 @@ def cleanup_path(path: str) -> str:
     >>> cleanup_path('a/ /b/c')
     Traceback (most recent call last):
     ...
-    ValueError: Invalid path: `a/ /b/c`. Path components must not be empty.
+    ValueError: Invalid path: `a/ /b/c`. Path components cannot contain leading or trailing whitespace.
     >>> cleanup_path('a/b/c ')
     Traceback (most recent call last):
     ...
-    ValueError: Invalid path: `a/b/c `. Path cannot contain leading or trailing whitespace.
+    ValueError: Invalid path: `a/b/c `. Path components cannot contain leading or trailing whitespace.
     """
 
     if path.strip() in ("", "/"):
         raise ValueError(f"Invalid path: `{path}`.")
 
-    if path.startswith("/"):
-        path = path[1:]
+    orig_parts = path.split("/")
+    parts = [x.strip() for x in orig_parts]
 
-    if path.endswith("/"):
+    for i, part in enumerate(parts):
+        if part != orig_parts[i]:
+            raise ValueError(f"Invalid path: `{path}`. Path components cannot contain leading or trailing whitespace.")
+
+    # Skip the first slash, if present
+    if parts[0] == "":
+        parts = parts[1:]
+
+    if parts[-1] == "":
         raise ValueError(f"Invalid path: `{path}`. Path must not end with a slash.")
 
-    if not all(x.strip() for x in path.split("/")):
+    if not all(parts):
         raise ValueError(f"Invalid path: `{path}`. Path components must not be empty.")
 
-    if path[0].lstrip() != path[0] or path[-1].rstrip() != path[-1]:
-        raise ValueError(f"Invalid path: `{path}`. Path cannot contain leading or trailing whitespace.")
-
-    return path
+    return "/".join(parts)
 
 
 def accumulate_dict_values(value: Union[ValueType, dict[str, ValueType]], path_or_base: str) -> dict[str, Any]:

--- a/src/neptune_scale/api/validation.py
+++ b/src/neptune_scale/api/validation.py
@@ -10,6 +10,7 @@ __all__ = (
 
 from typing import (
     Any,
+    Optional,
     Union,
 )
 
@@ -55,10 +56,29 @@ def verify_project_qualified_name(var_name: str, var: Any) -> None:
 def verify_collection_type(
     var_name: str, var: Union[list, set, tuple], expected_type: Union[type, tuple], allow_none: bool = True
 ) -> None:
-    if var is None and not allow_none:
-        raise ValueError(f"{var_name} must not be None")
+    if var is None:
+        if not allow_none:
+            raise ValueError(f"{var_name} must not be None")
+        return
 
     verify_type(var_name, var, (list, set, tuple))
 
     for value in var:
         verify_type(f"elements of collection '{var_name}'", value, expected_type)
+
+
+def verify_dict_type(
+    var_name: str, var: Optional[dict[Any, Any]], expected_type: Union[type, tuple], allow_none: bool = True
+) -> None:
+    if var is None:
+        if not allow_none:
+            raise ValueError(f"{var_name} must not be None")
+        return
+
+    verify_type(var_name, var, dict)
+
+    for key, value in var.items():
+        if not isinstance(key, str):
+            raise TypeError(f"Keys of dictionary '{var_name}' must be strings (got `{key}`)")
+
+        verify_type(f"Values of dictionary '{var_name}'", value, expected_type)


### PR DESCRIPTION
`AttributeStore.log()` is now responsible for feeding data to the `OperationsQueue`.
Some additional cleanups are there as well.