### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: arc-runner-set
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/unit-in-pull-request.yml
+++ b/.github/workflows/unit-in-pull-request.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
-        python-version: ["3.8"]
+        os: [ ubuntu, windows, macos ]
+        python-version: [ "3.9" ]
     name: 'test (${{ matrix.os }} - py${{ matrix.python-version }})'
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu, windows, macos]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        os: [ ubuntu, windows, macos ]
 
     name: 'test (${{ matrix.os }} - py${{ matrix.python-version }})'
     runs-on: ${{ matrix.os }}-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added function `neptune_scale.list_projects()` to list all projects the current user has access to ([#97](https://github.com/neptune-ai/neptune-client-scale/pull/97))
 
 ### Changed
+- Removed support for Python 3.8
 - Neptune will now skip non-finite metric values by default, instead of raising an error. This can be configured using
   the new `NEPTUNE_SKIP_NON_FINITE_METRICS` environment variable ([#85](https://github.com/neptune-ai/neptune-client-scale/pull/85))
 - Made default error callback logs more informative ([#78](https://github.com/neptune-ai/neptune-client-scale/pull/78))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ style = "semver"
 pattern = "default-unprefixed"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 neptune-api = "^0.8.0"
 more-itertools = "^10.0.0"
@@ -54,7 +54,7 @@ keywords = [
 
 [tool.black]
 line-length = 120
-target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target_version = ['py39', 'py310', 'py311', 'py312', 'py313']
 include = '\.pyi?$,\_pb2\.py$'
 exclude = '''
 /(
@@ -74,7 +74,7 @@ force_grid_wrap = 2
 
 [tool.ruff]
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["F", "UP"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = ["F", "UP"]
 ignore = ["UP006", "UP007"]
 
 [tool.mypy]
+python_version = "3.9"
 files = 'src/neptune_scale'
 mypy_path = "stubs"
 install_types = "True"

--- a/src/neptune_scale/api/attribute.py
+++ b/src/neptune_scale/api/attribute.py
@@ -1,18 +1,16 @@
 import functools
 import itertools
 import warnings
+from collections.abc import (
+    Collection,
+    Iterator,
+)
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Collection,
-    Dict,
-    Iterator,
-    List,
     Optional,
-    Set,
-    Tuple,
     Union,
     cast,
 )
@@ -52,7 +50,7 @@ ValueType = Any  # Union[float, int, str, bool, datetime, Tuple, List, Dict, Set
 class AttributeStore:
     def __init__(self, run: "Run") -> None:
         self._run = run
-        self._attributes: Dict[str, Attribute] = {}
+        self._attributes: dict[str, Attribute] = {}
 
     def __getitem__(self, path: str) -> "Attribute":
         path = cleanup_path(path)
@@ -72,10 +70,10 @@ class AttributeStore:
         self,
         step: Optional[Union[float, int]] = None,
         timestamp: Optional[Union[datetime, float]] = None,
-        configs: Optional[Dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]] = None,
-        metrics: Optional[Dict[str, Union[float, int]]] = None,
-        tags_add: Optional[Dict[str, Union[List[str], Set[str], Tuple[str]]]] = None,
-        tags_remove: Optional[Dict[str, Union[List[str], Set[str], Tuple[str]]]] = None,
+        configs: Optional[dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]] = None,
+        metrics: Optional[dict[str, Union[float, int]]] = None,
+        tags_add: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
+        tags_remove: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
     ) -> None:
         # TODO: This should not call Run.log, but do the actual work. Reverse the current dependency so that this
         #       class handles all the logging
@@ -117,7 +115,7 @@ class Attribute:
     @warn_unsupported_params
     def append(
         self,
-        value: Union[Dict[str, Any], float],
+        value: Union[dict[str, Any], float],
         *,
         step: Union[float, int],
         timestamp: Optional[Union[float, datetime]] = None,
@@ -130,7 +128,7 @@ class Attribute:
     @warn_unsupported_params
     # TODO: this should be Iterable in Run as well
     # def add(self, values: Union[str, Iterable[str]], *, wait: bool = False) -> None:
-    def add(self, values: Union[str, Union[List[str], Set[str], Tuple[str]]], *, wait: bool = False) -> None:
+    def add(self, values: Union[str, Union[list[str], set[str], tuple[str]]], *, wait: bool = False) -> None:
         if isinstance(values, str):
             values = (values,)
         self._store.log(tags_add={self._path: values})
@@ -138,7 +136,7 @@ class Attribute:
     @warn_unsupported_params
     # TODO: this should be Iterable in Run as well
     # def remove(self, values: Union[str, Iterable[str]], *, wait: bool = False) -> None:
-    def remove(self, values: Union[str, Union[List[str], Set[str], Tuple[str]]], *, wait: bool = False) -> None:
+    def remove(self, values: Union[str, Union[list[str], set[str], tuple[str]]], *, wait: bool = False) -> None:
         if isinstance(values, str):
             values = (values,)
         self._store.log(tags_remove={self._path: values})
@@ -168,7 +166,7 @@ class Attribute:
     # TODO: change Run API to typehint timestamp as Union[datetime, float]
 
 
-def iter_nested(dict_: Dict[str, ValueType], path: str) -> Iterator[Tuple[Tuple[str, ...], ValueType]]:
+def iter_nested(dict_: dict[str, ValueType], path: str) -> Iterator[tuple[tuple[str, ...], ValueType]]:
     """Iterate a nested dictionary, yielding a tuple of path components and value.
 
     >>> list(iter_nested({"foo": 1, "bar": {"baz": 2}}, "base"))
@@ -187,7 +185,7 @@ def iter_nested(dict_: Dict[str, ValueType], path: str) -> Iterator[Tuple[Tuple[
     yield from _iter_nested(dict_, parts)
 
 
-def _iter_nested(dict_: Dict[str, ValueType], path_acc: Tuple[str, ...]) -> Iterator[Tuple[Tuple[str, ...], ValueType]]:
+def _iter_nested(dict_: dict[str, ValueType], path_acc: tuple[str, ...]) -> Iterator[tuple[tuple[str, ...], ValueType]]:
     if not dict_:
         raise ValueError("The dictionary cannot be empty or contain empty nested dictionaries.")
 
@@ -228,7 +226,7 @@ def cleanup_path(path: str) -> str:
     return path
 
 
-def accumulate_dict_values(value: Union[ValueType, Dict[str, ValueType]], path_or_base: str) -> Dict:
+def accumulate_dict_values(value: Union[ValueType, dict[str, ValueType]], path_or_base: str) -> dict:
     """
     >>> accumulate_dict_values(1, "foo")
     {'foo': 1}

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -10,11 +10,11 @@ import atexit
 import os
 import threading
 import time
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from datetime import datetime
 from typing import (
     Any,
-    Callable,
     Literal,
 )
 

--- a/src/neptune_scale/api/validation.py
+++ b/src/neptune_scale/api/validation.py
@@ -8,18 +8,14 @@ __all__ = (
     "verify_collection_type",
 )
 
-from typing import (
-    Any,
-    Type,
-    Union,
-)
+from typing import Any
 
 
-def get_type_name(var_type: Union[Type, tuple]) -> str:
+def get_type_name(var_type: type | tuple) -> str:
     return var_type.__name__ if hasattr(var_type, "__name__") else str(var_type)
 
 
-def verify_type(var_name: str, var: Any, expected_type: Union[Type, tuple]) -> None:
+def verify_type(var_name: str, var: Any, expected_type: type | tuple) -> None:
     try:
         if isinstance(expected_type, tuple):
             type_name = " or ".join(get_type_name(t) for t in expected_type)
@@ -54,7 +50,7 @@ def verify_project_qualified_name(var_name: str, var: Any) -> None:
 
 
 def verify_collection_type(
-    var_name: str, var: Union[list, set, tuple], expected_type: Union[type, tuple], allow_none: bool = True
+    var_name: str, var: list | set | tuple, expected_type: type | tuple, allow_none: bool = True
 ) -> None:
     if var is None and not allow_none:
         raise ValueError(f"{var_name} must not be None")

--- a/src/neptune_scale/net/api_client.py
+++ b/src/neptune_scale/net/api_client.py
@@ -21,11 +21,11 @@ import abc
 import functools
 import os
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from http import HTTPStatus
 from typing import (
     Any,
-    Callable,
     Literal,
 )
 

--- a/src/neptune_scale/net/projects.py
+++ b/src/neptune_scale/net/projects.py
@@ -4,8 +4,6 @@ from enum import Enum
 from json import JSONDecodeError
 from typing import (
     Any,
-    Dict,
-    List,
     Optional,
     cast,
 )
@@ -93,7 +91,7 @@ def _safe_json(response: httpx.Response) -> Any:
         return {}
 
 
-def get_project_list(*, api_token: Optional[str] = None) -> List[Dict]:
+def get_project_list(*, api_token: Optional[str] = None) -> list[dict]:
     client = HostedApiClient(api_token=_get_api_token(api_token))
 
     params = {
@@ -102,4 +100,4 @@ def get_project_list(*, api_token: Optional[str] = None) -> List[Dict]:
     }
 
     response = client.backend.get_httpx_client().request("get", PROJECTS_PATH_BASE, params=params)
-    return cast(List[Dict], response.json()["entries"])
+    return cast(list[dict], response.json()["entries"])

--- a/src/neptune_scale/net/serialization.py
+++ b/src/neptune_scale/net/serialization.py
@@ -8,11 +8,6 @@ __all__ = (
 )
 
 from datetime import datetime
-from typing import (
-    List,
-    Set,
-    Union,
-)
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
@@ -22,7 +17,7 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
 )
 
 
-def make_value(value: Union[Value, float, str, int, bool, datetime, List[str], Set[str]]) -> Value:
+def make_value(value: Value | float | str | int | bool | datetime | list[str] | set[str]) -> Value:
     if isinstance(value, Value):
         return value
     if isinstance(value, float):
@@ -46,7 +41,7 @@ def datetime_to_proto(dt: datetime) -> Timestamp:
     return Timestamp(seconds=int(dt_ts), nanos=int((dt_ts % 1) * 1e9))
 
 
-def make_step(number: Union[float, int], raise_on_step_precision_loss: bool = False) -> Step:
+def make_step(number: float | int, raise_on_step_precision_loss: bool = False) -> Step:
     """
     Converts a number to protobuf Step value. Example:
     >>> assert make_step(7.654321, True) == Step(whole=7, micro=654321)

--- a/src/neptune_scale/projects.py
+++ b/src/neptune_scale/projects.py
@@ -1,8 +1,6 @@
 import re
 from typing import (
-    List,
     Optional,
-    Tuple,
     cast,
 )
 
@@ -66,7 +64,7 @@ def create_project(
     return normalize_project_name(name, workspace)
 
 
-def extract_workspace_and_project(name: str, workspace: Optional[str] = None) -> Tuple[str, str]:
+def extract_workspace_and_project(name: str, workspace: Optional[str] = None) -> tuple[str, str]:
     """Return a tuple of (workspace name, project name) from the provided
     fully qualified project name, or a name + workspace
 
@@ -118,7 +116,7 @@ def normalize_project_name(name: str, workspace: Optional[str] = None) -> str:
     return f"{extracted_workspace_name}/{extracted_project_name}"
 
 
-def list_projects(*, api_token: Optional[str] = None) -> List[str]:
+def list_projects(*, api_token: Optional[str] = None) -> list[str]:
     """Lists projects that the account has access to.
 
     Args:

--- a/src/neptune_scale/sync/errors_tracking.py
+++ b/src/neptune_scale/sync/errors_tracking.py
@@ -5,7 +5,7 @@ __all__ = ("ErrorsQueue", "ErrorsMonitor")
 import multiprocessing
 import queue
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from neptune_scale.exceptions import (
     NeptuneAsyncLagThresholdExceeded,

--- a/src/neptune_scale/sync/lag_tracking.py
+++ b/src/neptune_scale/sync/lag_tracking.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 __all__ = ("LagTracker",)
 
+from collections.abc import Callable
 from time import monotonic
-from typing import Callable
 
 from neptune_scale.sync.errors_tracking import ErrorsQueue
 from neptune_scale.sync.operations_queue import OperationsQueue

--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -4,11 +4,13 @@ __all__ = ("MetadataSplitter",)
 
 import math
 import warnings
-from collections.abc import Iterator
+from collections.abc import (
+    Callable,
+    Iterator,
+)
 from datetime import datetime
 from typing import (
     Any,
-    Callable,
     TypeVar,
 )
 

--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -4,18 +4,12 @@ __all__ = ("MetadataSplitter",)
 
 import math
 import warnings
+from collections.abc import Iterator
 from datetime import datetime
 from typing import (
     Any,
     Callable,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    Set,
-    Tuple,
     TypeVar,
-    Union,
 )
 
 from more_itertools import peekable
@@ -46,18 +40,18 @@ logger = get_logger()
 T = TypeVar("T", bound=Any)
 
 
-class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
+class MetadataSplitter(Iterator[tuple[RunOperation, int]]):
     def __init__(
         self,
         *,
         project: str,
         run_id: str,
-        step: Optional[Union[int, float]],
+        step: int | float | None,
         timestamp: datetime,
-        configs: Dict[str, Union[float, bool, int, str, datetime, list, set, tuple]],
-        metrics: Dict[str, float],
-        add_tags: Dict[str, Union[List[str], Set[str], Tuple[str]]],
-        remove_tags: Dict[str, Union[List[str], Set[str], Tuple[str]]],
+        configs: dict[str, float | bool | int | str | datetime | list | set | tuple],
+        metrics: dict[str, float],
+        add_tags: dict[str, list[str] | set[str] | tuple[str]],
+        remove_tags: dict[str, list[str] | set[str] | tuple[str]],
         max_message_bytes_size: int = 1024 * 1024,
     ):
         self._step = None if step is None else make_step(number=step)
@@ -85,7 +79,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
         self._has_returned = False
         return self
 
-    def __next__(self) -> Tuple[RunOperation, int]:
+    def __next__(self) -> tuple[RunOperation, int]:
         update = UpdateRunSnapshot(
             step=self._step,
             timestamp=self._timestamp,
@@ -179,7 +173,7 @@ class MetadataSplitter(Iterator[Tuple[RunOperation, int]]):
 
         return size
 
-    def _skip_non_finite(self, step: Optional[float | int], metrics: Dict[str, float]) -> Iterator[Tuple[str, float]]:
+    def _skip_non_finite(self, step: float | int | None, metrics: dict[str, float]) -> Iterator[tuple[str, float]]:
         """Yields (metric, value) pairs, skipping non-finite values depending on the env setting."""
 
         for k, v in metrics.items():

--- a/src/neptune_scale/sync/operations_queue.py
+++ b/src/neptune_scale/sync/operations_queue.py
@@ -4,10 +4,7 @@ __all__ = ("OperationsQueue",)
 
 from multiprocessing import Queue
 from time import monotonic
-from typing import (
-    TYPE_CHECKING,
-    Optional,
-)
+from typing import TYPE_CHECKING
 
 from neptune_scale.api.validation import verify_type
 from neptune_scale.sync.parameters import (
@@ -40,7 +37,7 @@ class OperationsQueue(Resource):
         self._max_size: int = max_size
 
         self._sequence_id: int = 0
-        self._last_timestamp: Optional[float] = None
+        self._last_timestamp: float | None = None
         self._queue: Queue[SingleOperation] = Queue(maxsize=min(MAX_MULTIPROCESSING_QUEUE_SIZE, max_size))
 
     @property
@@ -53,11 +50,11 @@ class OperationsQueue(Resource):
             return self._sequence_id - 1
 
     @property
-    def last_timestamp(self) -> Optional[float]:
+    def last_timestamp(self) -> float | None:
         with self._lock:
             return self._last_timestamp
 
-    def enqueue(self, *, operation: RunOperation, size: Optional[int] = None, key: Optional[float] = None) -> None:
+    def enqueue(self, *, operation: RunOperation, size: int | None = None, key: float | None = None) -> None:
         try:
             is_metadata_update = operation.HasField("update")
             serialized_operation = operation.SerializeToString()

--- a/src/neptune_scale/util/abstract.py
+++ b/src/neptune_scale/util/abstract.py
@@ -5,10 +5,6 @@ from abc import (
     abstractmethod,
 )
 from types import TracebackType
-from typing import (
-    Optional,
-    Type,
-)
 
 
 class AutoCloseable(ABC):
@@ -20,9 +16,9 @@ class AutoCloseable(ABC):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         self.close()
 

--- a/src/neptune_scale/util/process_killer.py
+++ b/src/neptune_scale/util/process_killer.py
@@ -1,7 +1,6 @@
 __all__ = ["kill_me"]
 
 import os
-from typing import List
 
 import psutil
 
@@ -41,7 +40,7 @@ def _kill(process: psutil.Process) -> None:
         pass
 
 
-def _get_process_children(process: psutil.Process) -> List[psutil.Process]:
+def _get_process_children(process: psutil.Process) -> list[psutil.Process]:
     try:
         return process.children(recursive=True)
     except psutil.NoSuchProcess:

--- a/src/neptune_scale/util/process_link.py
+++ b/src/neptune_scale/util/process_link.py
@@ -2,11 +2,11 @@ import multiprocessing
 import os
 import queue
 import threading
+from collections.abc import Callable
 from functools import partial
 from multiprocessing.connection import Connection
 from typing import (
     Any,
-    Callable,
     Optional,
 )
 

--- a/src/neptune_scale/util/shared_var.py
+++ b/src/neptune_scale/util/shared_var.py
@@ -1,7 +1,7 @@
 import multiprocessing
+from collections.abc import Callable
 from types import TracebackType
 from typing import (
-    Callable,
     Generic,
     Optional,
     TypeVar,

--- a/src/neptune_scale/util/shared_var.py
+++ b/src/neptune_scale/util/shared_var.py
@@ -4,7 +4,6 @@ from typing import (
     Callable,
     Generic,
     Optional,
-    Type,
     TypeVar,
     cast,
 )
@@ -66,7 +65,7 @@ class SharedVar(Generic[T]):
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:

--- a/src/neptune_scale/util/styles.py
+++ b/src/neptune_scale/util/styles.py
@@ -2,7 +2,6 @@ __all__ = ("STYLES", "ensure_style_detected")
 
 import os
 import platform
-from typing import Dict
 
 from neptune_scale.util.envs import DISABLE_COLORS
 
@@ -49,7 +48,7 @@ EMPTY_STYLES = {
 }
 
 
-STYLES: Dict[str, str] = {}
+STYLES: dict[str, str] = {}
 
 
 def ensure_style_detected() -> None:

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -262,7 +262,7 @@ def test_split_large_tags():
     assert all(op.update.timestamp == Timestamp(seconds=1722341532, nanos=21934) for op, _ in result)
 
     # Check if all StringSet values are split correctly
-    assert set([key for op, _ in result for key in op.update.modify_sets.keys()]) == set(
+    assert {key for op, _ in result for key in op.update.modify_sets.keys()} == set(
         list(add_tags.keys()) + list(remove_tags.keys())
     )
 

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -1,6 +1,5 @@
 import queue
 import time
-from typing import List
 from unittest.mock import Mock
 
 import pytest
@@ -20,7 +19,7 @@ from neptune_scale.sync.sync_process import SenderThread
 from neptune_scale.util.shared_var import SharedInt
 
 
-def response(request_ids: List[str], status_code: int = 200):
+def response(request_ids: list[str], status_code: int = 200):
     body = SubmitResponse(request_ids=request_ids, request_id=request_ids[-1] if request_ids else None)
     content = body.SerializeToString()
     return Mock(status_code=status_code, content=content, parsed=body)


### PR DESCRIPTION
Changes:
 * bump the minimal Python version to 3.9 in all the tools
 * run `pyupgrade --py39-plus` on the codebase to change typehints to PEP585-style
 * manually change `typing.Callable` to `collections.abc.Callable`