### PR TITLE
Make `OperationDispatcherThread` accept multiple consumers

### DIFF
--- a/src/neptune_scale/sync/sync_process.py
+++ b/src/neptune_scale/sync/sync_process.py
@@ -6,6 +6,7 @@ import multiprocessing
 import queue
 import signal
 import threading
+from collections.abc import Iterable
 from multiprocessing import (
     Process,
     Queue,
@@ -16,6 +17,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    Protocol,
     TypeVar,
 )
 
@@ -38,7 +40,6 @@ from neptune_scale.exceptions import (
     NeptuneConnectionLostError,
     NeptuneFloatValueNanInfUnsupported,
     NeptuneInternalServerError,
-    NeptuneOperationsQueueMaxSizeExceeded,
     NeptuneProjectInvalidName,
     NeptuneProjectNotFound,
     NeptuneRetryableError,
@@ -234,6 +235,10 @@ class SyncProcess(Process):
         logger.info("Data synchronization finished")
 
 
+class SupportsPutNowait(Protocol):
+    def put_nowait(self, element: SingleOperation) -> None: ...
+
+
 class SyncProcessWorker(WithResources):
     def __init__(
         self,
@@ -262,11 +267,7 @@ class SyncProcessWorker(WithResources):
             last_queued_seq=last_queued_seq,
             mode=mode,
         )
-        self._operation_dispatcher_thread = OperationDispatcherThread(
-            input_queue=input_queue,
-            operations_queue=self._internal_operations_queue,
-            errors_queue=self._errors_queue,
-        )
+
         self._status_tracking_thread = StatusTrackingThread(
             api_token=api_token,
             mode=mode,
@@ -275,6 +276,12 @@ class SyncProcessWorker(WithResources):
             status_tracking_queue=self._status_tracking_queue,
             last_ack_seq=last_ack_seq,
             last_ack_timestamp=last_ack_timestamp,
+        )
+
+        self._operation_dispatcher_thread = OperationDispatcherThread(
+            input_queue=input_queue,
+            consumers=[self._internal_operations_queue],
+            errors_queue=self._errors_queue,
         )
 
     @property
@@ -304,16 +311,22 @@ class SyncProcessWorker(WithResources):
 
 
 class OperationDispatcherThread(Daemon, Resource):
+    """Reads incoming messages from a multiprocessing.Queue, and dispatches them to a list of consumers,
+    which can be of type `queue.Queue`, but also any other object that supports put_nowait() method.
+
+    If any of the consumers' put_nowait() raises queue.Full, the thread will stop processing further operations.
+    """
+
     def __init__(
         self,
         input_queue: multiprocessing.Queue[SingleOperation],
-        operations_queue: AggregatingQueue,
+        consumers: Iterable[SupportsPutNowait],
         errors_queue: ErrorsQueue,
     ) -> None:
         super().__init__(name="OperationDispatcherThread", sleep_time=INTERNAL_QUEUE_FEEDER_THREAD_SLEEP_TIME)
 
         self._input_queue: multiprocessing.Queue[SingleOperation] = input_queue
-        self._operations_queue: AggregatingQueue = operations_queue
+        self._consumers = tuple(consumers)
         self._errors_queue: ErrorsQueue = errors_queue
 
         self._latest_unprocessed: Optional[SingleOperation] = None
@@ -334,22 +347,22 @@ class OperationDispatcherThread(Daemon, Resource):
     def work(self) -> None:
         try:
             while not self._is_interrupted():
-                operation = self.get_next()
-                if operation is None:
+                if (operation := self.get_next()) is None:
                     continue
 
                 try:
-                    self._operations_queue.put_nowait(operation)
+                    for consumer in self._consumers:
+                        consumer.put_nowait(operation)
                     self.commit()
-                except queue.Full:
-                    logger.debug(
-                        "Operations queue is full (%d elements), waiting for free space", self._operations_queue.maxsize
-                    )
-                    self._errors_queue.put(
-                        NeptuneOperationsQueueMaxSizeExceeded(max_size=self._operations_queue.maxsize)
-                    )
-                    # Sleep before retry
-                    break
+                except queue.Full as e:
+                    # We have two ways to deal with this situation:
+                    # 1. Consider this a fatal error, and stop processing further operations.
+                    # 2. Retry, assuming that any consumer that _did_ manage to receive the operation, is
+                    #    idempotent and can handle the same operation again.
+                    #
+                    # Currently, we choose 1.
+                    logger.error("Operation queue overflow. Neptune will not process further operations.")
+                    raise e
         except Exception as e:
             self._errors_queue.put(e)
             self.interrupt()


### PR DESCRIPTION
Instead of pushing messages to a single queue, it's now possible to copy the message to an arbitrary list of consumers. This comes with a quirk explained in the comments
