### PR TITLE
Free up resources sooner & fix a race condition when process link is closed.

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -642,12 +642,11 @@ class Run(WithResources, AbstractContextManager):
                     if not self._close_completed.is_set() and wait_seq.value >= self._operations_queue.last_sequence_id:
                         return True
 
-                if is_closing:
-                    if threading.current_thread() != self._closing_thread:
-                        if verbose:
-                            logger.warning("Waiting interrupted by run termination")
+                if is_closing and threading.current_thread() != self._closing_thread:
+                    if verbose:
+                        logger.warning("Waiting interrupted by run termination")
 
-                        self._close_completed.wait(wait_time)
+                    self._close_completed.wait(wait_time)
 
                     return False
 

--- a/src/neptune_scale/util/process_link.py
+++ b/src/neptune_scale/util/process_link.py
@@ -223,7 +223,7 @@ class ProcessLinkWorker(Daemon):
                 raise RuntimeError(f"Invalid challenge response: {msg}")
             success = True
         except Exception as e:
-            logger.error(f"{self}: unexpected error while sending data: {e}")
+            logger.error(f"{self}: unexpected error while sending data: {e!r}")
             with self._lock:
                 self._closed = True
             self.interrupt()

--- a/src/neptune_scale/util/process_link.py
+++ b/src/neptune_scale/util/process_link.py
@@ -226,6 +226,8 @@ class ProcessLinkWorker(Daemon):
             logger.error(f"{self}: unexpected error while sending data: {e!r}")
             with self._lock:
                 self._closed = True
+
+            self._conn.close()
             self.interrupt()
 
         self._start_done.set()
@@ -240,6 +242,8 @@ class ProcessLinkWorker(Daemon):
         if self._stop_event.is_set():
             # This will notify the other side about us closing the link
             if not self._conn.closed:
+                with self._lock:
+                    self._closed = True
                 self._conn.close()
 
             self.interrupt()
@@ -262,10 +266,10 @@ class ProcessLinkWorker(Daemon):
 
             with self._lock:
                 self._closed = True
+            self._conn.close()
 
             if not self._stop_event.is_set():
                 self._safe_callback(self._on_link_closed)
-                self._conn.close()
 
             self.interrupt()
 

--- a/tests/unit/test_run_init_and_close.py
+++ b/tests/unit/test_run_init_and_close.py
@@ -118,4 +118,5 @@ def test_run_creation_during_initialization_error(api_token):
         )
 
     assert callback_finished.wait(timeout=10)
-    assert run.wait_for_processing(timeout=1)
+    # The run should be terminated, so wait_for_processing should return False
+    assert not run.wait_for_processing(timeout=1)


### PR DESCRIPTION
1. fix a race condition where the child process could be terminated before we get to `process_link.close()` in `Run._close()`
2. set sensitive, IPC-related resources to None, to force releasing OS resources sooner