### PR TITLE
Fix logic in `Run._wait()`

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -634,12 +634,11 @@ class Run(WithResources, AbstractContextManager):
                     if wait_seq.value >= self._operations_queue.last_sequence_id:
                         return True
 
-                if is_closing:
-                    if threading.current_thread() != self._closing_thread:
-                        if verbose:
-                            logger.warning("Waiting interrupted by run termination")
+                if is_closing and threading.current_thread() != self._closing_thread:
+                    if verbose:
+                        logger.warning("Waiting interrupted by run termination")
 
-                        self._close_completed.wait(wait_time)
+                    self._close_completed.wait(wait_time)
 
                     return False
 


### PR DESCRIPTION
The bug introduced by #118 made the thread that called `Run.close()` immediately return from `_wait()`, causing in-flight operations to be lost, as the calling thread is the one that's supposed to wait until all is processed.

The tests did not catch that, so I'm issuing this PR as a quick fix. E2E tests for logging and verifying large amounts of data need to be added separately.