### PR TITLE
Don't error out on child process exit if we're already closing the run

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -312,8 +312,8 @@ class Run(WithResources, AbstractContextManager):
             if not self._is_closing:
                 logger.error("Child process closed unexpectedly. Terminating.")
 
-        # Make sure all the error handling is done from a single thread - self._errors_monitor
-        self._errors_queue.put(NeptuneSynchronizationStopped())
+                # Make sure all the error handling is done from a single thread - self._errors_monitor
+                self._errors_queue.put(NeptuneSynchronizationStopped())
 
     @property
     def resources(self) -> tuple[Resource, ...]:

--- a/src/neptune_scale/util/process_link.py
+++ b/src/neptune_scale/util/process_link.py
@@ -223,7 +223,7 @@ class ProcessLinkWorker(Daemon):
                 raise RuntimeError(f"Invalid challenge response: {msg}")
             success = True
         except Exception as e:
-            logger.error(f"{self}: unexpected error while sending data: {e}")
+            logger.error(f"{self}: unexpected error while sending data: {e!r}")
             with self._lock:
                 self._closed = True
             self.interrupt()


### PR DESCRIPTION
We could get called before `process_link.stop()` is called in `_close()`.

Also log `repr` of errors in process link for better debugging