### PR TITLE
Add support for metric previews

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         args: [ --config-file, pyproject.toml ]
         pass_filenames: false
         additional_dependencies:
-          - neptune-api==0.7.0b
+          - neptune-api==0.11.0
           - more-itertools
           - backoff
 default_language_version:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,4 @@ pytest
 pytest-timeout
 pytest-xdist
 freezegun
-neptune-fetcher @ git+https://github.com/neptune-ai/neptune-fetcher.git@7912dfbbffcc676079870733572553116e569efa
+neptune-fetcher @ git+https://github.com/neptune-ai/neptune-fetcher.git@30f7668b0e5c42f60140118134c67094b566dc82

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pattern = "default-unprefixed"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-neptune-api = "^0.10.0"
+neptune-api = "^0.11.0"
 more-itertools = "^10.0.0"
 psutil = "^5.0.0"
 backoff = "^2.0.0"

--- a/src/neptune_scale/api/attribute.py
+++ b/src/neptune_scale/api/attribute.py
@@ -99,8 +99,9 @@ class AttributeStore:
         )
 
         for operation, metadata_size in splitter:
-            key = metrics.step if metrics is not None else None
+            key = metrics.batch_key() if metrics is not None else None
             self._operations_queue.enqueue(operation=operation, size=metadata_size, key=key)
+
 
 class Attribute:
     """Objects of this class are returned on dict-like access to Run. Attributes have a path and
@@ -128,8 +129,8 @@ class Attribute:
         value: Union[dict[str, Any], float],
         *,
         step: Union[float, int],
-        preview: Optional[bool] = False,
-        preview_completion: Optional[float] = 0.0,
+        preview: bool = False,
+        preview_completion: Optional[float] = None,
         timestamp: Optional[Union[float, datetime]] = None,
         wait: bool = False,
         **kwargs: Any,

--- a/src/neptune_scale/api/metrics.py
+++ b/src/neptune_scale/api/metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import (
     Optional,
@@ -22,14 +23,17 @@ class Metrics:
     """Class representing a set of metrics at a single step"""
     data: dict[str, Union[float, int]]
     step: Optional[Union[float, int]]
-    preview: Optional[bool] = False
-    preview_completion: Optional[float] = 0.0
+    preview: bool = False
+    preview_completion: Optional[float] = None
 
     def __post_init__(self):
         verify_type("metrics", self.data, dict)
         verify_type("step", self.step, (float, int, type(None)))
         verify_type("preview", self.preview, bool)
-        verify_type("preview_completion", self.preview_completion, float)
+        verify_type("preview_completion", self.preview_completion, (float, type(None)))
         verify_dict_type("metrics", self.data, (float, int))
-        if self.preview_completion:
+        if self.preview_completion is not None:
             verify_value_between("preview_completion", self.preview_completion, 0.0, 1.0)
+
+    def batch_key(self) -> Hashable:
+        return (self.step, self.preview, self.preview_completion)

--- a/src/neptune_scale/api/metrics.py
+++ b/src/neptune_scale/api/metrics.py
@@ -13,20 +13,19 @@ from neptune_scale.api.validation import (
     verify_value_between,
 )
 
-__all__ = (
-    "Metrics",
-)
+__all__ = ("Metrics",)
 
 
-@dataclass(slots=True)
+@dataclass
 class Metrics:
     """Class representing a set of metrics at a single step"""
+
     data: dict[str, Union[float, int]]
     step: Optional[Union[float, int]]
     preview: bool = False
     preview_completion: Optional[float] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         verify_type("metrics", self.data, dict)
         verify_type("step", self.step, (float, int, type(None)))
         verify_type("preview", self.preview, bool)

--- a/src/neptune_scale/api/metrics.py
+++ b/src/neptune_scale/api/metrics.py
@@ -32,6 +32,13 @@ class Metrics:
         verify_type("preview", self.preview, bool)
         verify_type("preview_completion", self.preview_completion, (float, type(None)))
         verify_dict_type("metrics", self.data, (float, int))
+        if not self.preview:
+            if self.preview_completion not in (None, 1.0):
+                raise ValueError("preview_completion can only be specified for metric previews")
+            # we don't send info about preview if preview=False
+            # and dropping 1.0 (even if it's technically a correct value)
+            # reduces chance of errors down the line
+            self.preview_completion = None
         if self.preview_completion is not None:
             verify_value_between("preview_completion", self.preview_completion, 0.0, 1.0)
 

--- a/src/neptune_scale/api/metrics.py
+++ b/src/neptune_scale/api/metrics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import (
+    Optional,
+    Union,
+)
+
+from neptune_scale.api.validation import (
+    verify_dict_type,
+    verify_type,
+    verify_value_between,
+)
+
+__all__ = (
+    "Metrics",
+)
+
+
+@dataclass(slots=True)
+class Metrics:
+    """Class representing a set of metrics at a single step"""
+    data: dict[str, Union[float, int]]
+    step: Optional[Union[float, int]]
+    preview: Optional[bool] = False
+    preview_completion: Optional[float] = 0.0
+
+    def __post_init__(self):
+        verify_type("metrics", self.data, dict)
+        verify_type("step", self.step, (float, int, type(None)))
+        verify_type("preview", self.preview, bool)
+        verify_type("preview_completion", self.preview_completion, float)
+        verify_dict_type("metrics", self.data, (float, int))
+        if self.preview_completion:
+            verify_value_between("preview_completion", self.preview_completion, 0.0, 1.0)

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -394,8 +394,8 @@ class Run(WithResources, AbstractContextManager):
         step: Union[float, int],
         *,
         timestamp: Optional[datetime] = None,
-        preview: Optional[bool] = False,
-        preview_completion: Optional[float] = 0.0,
+        preview: bool = False,
+        preview_completion: Optional[float] = None,
     ) -> None:
         """
         Logs the specified metrics to a Neptune run.
@@ -413,14 +413,14 @@ class Run(WithResources, AbstractContextManager):
             data: Dictionary of metrics to log.
                 Each metric value is associated with a step.
                 To log multiple metrics at once, pass multiple key-value pairs.
-            step: Index of the log entry. Must be increasing.
+            step: Index of the log entry. Must be increasing unless preview is set to True.
                 Tip: Using float rather than int values can be useful, for example, when logging substeps in a batch.
             timestamp (optional): Time of logging the metadata. If not provided, the current time is used. If provided,
                 and `timestamp.tzinfo` is not set, the time is assumed to be in the local timezone.
             preview (optional): If set marks the logged metrics as preview values. Preview values may later be overwritten
                 by another preview or by a non-preview value. Writing another preview for the same step overrides the previous
                 value, even if preview_completion is lower than previous. Previews may no longer be logged after a non-preview
-                value is logged for a given metric for a given step.
+                value is logged for a given metric with greator or equal step.
             preview_completion (optional): A value between 0 and 1 that marks the level of completion of the calculation
                 that produced the preview value (higher values mean calculation closer to being complete). Ignored if preview
                 is set to False.

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -24,8 +24,8 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import ForkPoint
 from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import Run as CreateRun
 from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
 
-from neptune_scale.api.metrics import Metrics
 from neptune_scale.api.attribute import AttributeStore
+from neptune_scale.api.metrics import Metrics
 from neptune_scale.api.validation import (
     verify_dict_type,
     verify_max_length,
@@ -438,13 +438,15 @@ class Run(WithResources, AbstractContextManager):
                 )
             ```
         """
-        self._log(timestamp=timestamp,
-                 metrics=Metrics(
-                     data=data,
-                     step=step,
-                     preview=preview,
-                     preview_completion=preview_completion,
-                ))
+        self._log(
+            timestamp=timestamp,
+            metrics=Metrics(
+                data=data,
+                step=step,
+                preview=preview,
+                preview_completion=preview_completion,
+            ),
+        )
 
     def log_configs(
         self, data: Optional[dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]] = None

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -24,6 +24,7 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import ForkPoint
 from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import Run as CreateRun
 from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
 
+from neptune_scale.api.metrics import Metrics
 from neptune_scale.api.attribute import AttributeStore
 from neptune_scale.api.validation import (
     verify_dict_type,
@@ -393,6 +394,8 @@ class Run(WithResources, AbstractContextManager):
         step: Union[float, int],
         *,
         timestamp: Optional[datetime] = None,
+        preview: Optional[bool] = False,
+        preview_completion: Optional[float] = 0.0,
     ) -> None:
         """
         Logs the specified metrics to a Neptune run.
@@ -414,7 +417,15 @@ class Run(WithResources, AbstractContextManager):
                 Tip: Using float rather than int values can be useful, for example, when logging substeps in a batch.
             timestamp (optional): Time of logging the metadata. If not provided, the current time is used. If provided,
                 and `timestamp.tzinfo` is not set, the time is assumed to be in the local timezone.
-
+            preview (optional): If set marks the logged metrics as preview values. Preview values may later be overwritten
+                by another preview or by a non-preview value. Writing another preview for the same step overrides the previous
+                value, even if preview_completion is lower than previous. Previews may no longer be logged after a non-preview
+                value is logged for a given metric for a given step.
+            preview_completion (optional): A value between 0 and 1 that marks the level of completion of the calculation
+                that produced the preview value (higher values mean calculation closer to being complete). Ignored if preview
+                is set to False.
+                Note: Metric preview with preview_completion of 1.0 is still considered a preview and can be overwritten.
+                      The final value of a metric for a given step needs to be logged with preview=False.
 
         Examples:
             ```
@@ -427,7 +438,13 @@ class Run(WithResources, AbstractContextManager):
                 )
             ```
         """
-        self.log(step=step, timestamp=timestamp, metrics=data)
+        self._log(timestamp=timestamp,
+                 metrics=Metrics(
+                     data=data,
+                     step=step,
+                     preview=preview,
+                     preview_completion=preview_completion,
+                ))
 
     def log_configs(
         self, data: Optional[dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]] = None
@@ -463,7 +480,7 @@ class Run(WithResources, AbstractContextManager):
                 )
             ```
         """
-        self.log(configs=data)
+        self._log(configs=data)
 
     def add_tags(self, tags: Union[list[str], set[str], tuple[str]], group_tags: bool = False) -> None:
         """
@@ -482,7 +499,7 @@ class Run(WithResources, AbstractContextManager):
             ```
         """
         name = "sys/tags" if not group_tags else "sys/group_tags"
-        self.log(tags_add={name: tags})
+        self._log(tags_add={name: tags})
 
     def remove_tags(self, tags: Union[list[str], set[str], tuple[str]], group_tags: bool = False) -> None:
         """
@@ -501,7 +518,7 @@ class Run(WithResources, AbstractContextManager):
             ```
         """
         name = "sys/tags" if not group_tags else "sys/group_tags"
-        self.log(tags_remove={name: tags})
+        self._log(tags_remove={name: tags})
 
     def log(
         self,
@@ -513,6 +530,7 @@ class Run(WithResources, AbstractContextManager):
         tags_remove: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
     ) -> None:
         """
+        This method is retained for backward compatibility.
         See one of the following instead:
 
         - log_configs()
@@ -520,16 +538,24 @@ class Run(WithResources, AbstractContextManager):
         - add_tags()
         - remove_tags()
         """
+        mtr = Metrics(step=step, data=metrics) if metrics is not None else None
+        self._log(timestamp=timestamp, configs=configs, metrics=mtr, tags_add=tags_add, tags_remove=tags_remove)
 
-        verify_type("step", step, (float, int, type(None)))
+    def _log(
+        self,
+        timestamp: Optional[datetime] = None,
+        configs: Optional[dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]] = None,
+        metrics: Optional[Metrics] = None,
+        tags_add: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
+        tags_remove: Optional[dict[str, Union[list[str], set[str], tuple[str]]]] = None,
+    ) -> None:
         verify_type("timestamp", timestamp, (datetime, type(None)))
         verify_type("configs", configs, (dict, type(None)))
-        verify_type("metrics", metrics, (dict, type(None)))
+        verify_type("metrics", metrics, (Metrics, type(None)))
         verify_type("tags_add", tags_add, (dict, type(None)))
         verify_type("tags_remove", tags_remove, (dict, type(None)))
 
         verify_dict_type("configs", configs, (float, bool, int, str, datetime, list, set, tuple))
-        verify_dict_type("metrics", metrics, (float, int))
         verify_dict_type("tags_add", tags_add, (list, set, tuple))
         verify_dict_type("tags_remove", tags_remove, (list, set, tuple))
 
@@ -540,7 +566,11 @@ class Run(WithResources, AbstractContextManager):
             return
 
         self._attr_store.log(
-            step=step, timestamp=timestamp, configs=configs, metrics=metrics, tags_add=tags_add, tags_remove=tags_remove
+            timestamp=timestamp,
+            configs=configs,
+            metrics=metrics,
+            tags_add=tags_add,
+            tags_remove=tags_remove,
         )
 
     def _wait(

--- a/src/neptune_scale/api/validation.py
+++ b/src/neptune_scale/api/validation.py
@@ -85,7 +85,7 @@ def verify_dict_type(
 
 
 def verify_value_between(
-        var_name: str, var: Union[int, float], expected_min: Union[int, float], expected_max: Union[int, float]
+    var_name: str, var: Union[int, float], expected_min: Union[int, float], expected_max: Union[int, float]
 ) -> None:
     if var > expected_max or var < expected_min:
         raise ValueError(f"{var_name} must have a value between {expected_min} and {expected_max}")

--- a/src/neptune_scale/api/validation.py
+++ b/src/neptune_scale/api/validation.py
@@ -82,3 +82,10 @@ def verify_dict_type(
             raise TypeError(f"Keys of dictionary '{var_name}' must be strings (got `{key}`)")
 
         verify_type(f"Values of dictionary '{var_name}'", value, expected_type)
+
+
+def verify_value_between(
+        var_name: str, var: Union[int, float], expected_min: Union[int, float], expected_max: Union[int, float]
+) -> None:
+    if var > expected_max or var < expected_min:
+        raise ValueError(f"{var_name} must have a value between {expected_min} and {expected_max}")

--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -38,6 +38,7 @@ __all__ = (
     "NeptuneProjectNotProvided",
     "NeptuneApiTokenNotProvided",
     "NeptuneTooManyRequestsResponseError",
+    "NeptunePreviewStepNotAfterLastCommittedStep",
 )
 
 from typing import Any
@@ -459,4 +460,16 @@ Make sure to specify the API token in the `api_token` parameter of the `Run`
 constructor or with the `NEPTUNE_API_TOKEN` environment variable.
 
 For instructions, see https://docs-beta.neptune.ai/api_token
+"""
+
+
+class NeptunePreviewStepNotAfterLastCommittedStep(NeptuneScaleError):
+    message = """
+{h1}
+NeptunePreviewStepNotAfterLastCommittedStep: Metric preview can only be logged
+for steps greater than the last committed value.
+{end}
+It looks like you tried to log a preview (incomplete) metric update for a step that isn't after
+the last fully committed (complete) update. Once a complete value is recorded, any preview updates
+must only be added for later steps. Please adjust the order of your updates and try again.
 """

--- a/src/neptune_scale/sync/aggregating_queue.py
+++ b/src/neptune_scale/sync/aggregating_queue.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ("AggregatingQueue",)
 
 import time
+from collections.abc import Hashable
 from queue import (
     Empty,
     Queue,
@@ -67,7 +68,7 @@ class AggregatingQueue(Resource):
     def get(self) -> BatchedOperations:
         start = time.monotonic()
 
-        batch_operations: dict[Optional[float], RunOperation] = {}
+        batch_operations: dict[Hashable, RunOperation] = {}
         batch_sequence_id: Optional[int] = None
         batch_timestamp: Optional[float] = None
 
@@ -153,7 +154,7 @@ class AggregatingQueue(Resource):
         )
 
 
-def create_run_batch(operations: dict[Optional[float], RunOperation]) -> RunOperation:
+def create_run_batch(operations: dict[Hashable, RunOperation]) -> RunOperation:
     if len(operations) == 1:
         return next(iter(operations.values()))
 

--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -18,12 +18,14 @@ from typing import (
 
 from more_itertools import peekable
 from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
+    Preview,
     SET_OPERATION,
     UpdateRunSnapshot,
     Value,
 )
 from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
 
+from neptune_scale.api.metrics import Metrics
 from neptune_scale.exceptions import (
     NeptuneFloatValueNanInfUnsupported,
     NeptuneScaleWarning,
@@ -50,20 +52,22 @@ class MetadataSplitter(Iterator[tuple[RunOperation, int]]):
         *,
         project: str,
         run_id: str,
-        step: Optional[Union[int, float]],
         timestamp: datetime,
         configs: Optional[dict[str, Union[float, bool, int, str, datetime, list, set, tuple]]],
-        metrics: Optional[dict[str, float]],
+        metrics: Optional[Metrics],
         add_tags: Optional[dict[str, Union[list[str], set[str], tuple[str]]]],
         remove_tags: Optional[dict[str, Union[list[str], set[str], tuple[str]]]],
         max_message_bytes_size: int = 1024 * 1024,
     ):
-        self._step = None if step is None else make_step(number=step)
+        self._should_skip_non_finite_metrics = envs.get_bool(envs.SKIP_NON_FINITE_METRICS, True)
+        self._step = make_step(number=metrics.step) if (metrics is not None and metrics.step is not None) else None
         self._timestamp = datetime_to_proto(timestamp)
         self._project = project
         self._run_id = run_id
         self._configs = peekable(configs.items()) if configs else None
-        self._metrics = peekable(self._skip_non_finite(step, metrics)) if metrics else None
+        self._metrics_data = peekable(self._skip_non_finite(metrics.step, metrics.data)) if metrics is not None else None
+        self._metrics_preview = metrics.preview if metrics is not None else False
+        self._metrics_preview_completion = metrics.preview_completion if metrics is not None else 0.0
         self._add_tags = peekable(add_tags.items()) if add_tags else None
         self._remove_tags = peekable(remove_tags.items()) if remove_tags else None
 
@@ -72,25 +76,17 @@ class MetadataSplitter(Iterator[tuple[RunOperation, int]]):
             - RunOperation(
                 project=self._project,
                 run_id=self._run_id,
-                update=UpdateRunSnapshot(step=self._step, timestamp=self._timestamp),
+                update=self._make_empty_update_snapshot(),
             ).ByteSize()
         )
-
         self._has_returned = False
-        self._should_skip_non_finite_metrics = envs.get_bool(envs.SKIP_NON_FINITE_METRICS, True)
 
     def __iter__(self) -> MetadataSplitter:
         self._has_returned = False
         return self
 
     def __next__(self) -> tuple[RunOperation, int]:
-        update = UpdateRunSnapshot(
-            step=self._step,
-            timestamp=self._timestamp,
-            assign={},
-            append={},
-            modify_sets={},
-        )
+        update = self._make_empty_update_snapshot()
         size = update.ByteSize()
 
         size = self.populate(
@@ -99,7 +95,7 @@ class MetadataSplitter(Iterator[tuple[RunOperation, int]]):
             size=size,
         )
         size = self.populate(
-            assets=self._metrics,
+            assets=self._metrics_data,
             update_producer=lambda key, value: update.append[key].MergeFrom(value),
             size=size,
         )
@@ -204,3 +200,14 @@ class MetadataSplitter(Iterator[tuple[RunOperation, int]]):
                     raise NeptuneFloatValueNanInfUnsupported(metric=k, step=step, value=v)
 
             yield k, v
+
+    def _make_empty_update_snapshot(self) -> UpdateRunSnapshot:
+        include_preview = self._metrics_data and self._metrics_preview
+        return UpdateRunSnapshot(
+            step=self._step,
+            preview = Preview(is_preview=True, completion_ratio=self._metrics_preview_completion) if include_preview else None,
+            timestamp=self._timestamp,
+            assign={},
+            append={},
+            modify_sets={},
+        )

--- a/src/neptune_scale/sync/operations_queue.py
+++ b/src/neptune_scale/sync/operations_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 __all__ = ("OperationsQueue",)
 
+from collections.abc import Hashable
 from multiprocessing import Queue
 from time import monotonic
 from typing import (
@@ -57,7 +58,7 @@ class OperationsQueue(Resource):
         with self._lock:
             return self._last_timestamp
 
-    def enqueue(self, *, operation: RunOperation, size: Optional[int] = None, key: Optional[float] = None) -> None:
+    def enqueue(self, *, operation: RunOperation, size: Optional[int] = None, key: Hashable = None) -> None:
         try:
             is_metadata_update = operation.HasField("update")
             serialized_operation = operation.SerializeToString()

--- a/src/neptune_scale/sync/queue_element.py
+++ b/src/neptune_scale/sync/queue_element.py
@@ -1,5 +1,6 @@
 __all__ = ("BatchedOperations", "SingleOperation")
 
+from collections.abc import Hashable
 from typing import (
     NamedTuple,
     Optional,
@@ -27,4 +28,4 @@ class SingleOperation(NamedTuple):
     # Size of the metadata in the operation (without project, family, run_id etc.)
     metadata_size: Optional[int]
     # Update metadata key
-    batch_key: Optional[float]
+    batch_key: Hashable

--- a/src/neptune_scale/sync/sync_process.py
+++ b/src/neptune_scale/sync/sync_process.py
@@ -58,6 +58,7 @@ from neptune_scale.exceptions import (
     NeptuneUnauthorizedError,
     NeptuneUnexpectedError,
     NeptuneUnexpectedResponseError,
+    NeptunePreviewStepNotAfterLastCommittedStep,
 )
 from neptune_scale.net.api_client import (
     ApiClient,
@@ -118,6 +119,7 @@ CODE_TO_ERROR: dict[IngestCode.ValueType, Optional[type[Exception]]] = {
     IngestCode.FLOAT_VALUE_NAN_INF_UNSUPPORTED: GenericFloatValueNanInfUnsupported,
     IngestCode.STRING_VALUE_EXCEEDS_SIZE_LIMIT: NeptuneStringValueExceedsSizeLimit,
     IngestCode.STRING_SET_EXCEEDS_SIZE_LIMIT: NeptuneStringSetExceedsSizeLimit,
+    IngestCode.SERIES_PREVIEW_STEP_NOT_AFTER_LAST_COMMITTED_STEP: NeptunePreviewStepNotAfterLastCommittedStep,
 }
 
 

--- a/src/neptune_scale/sync/sync_process.py
+++ b/src/neptune_scale/sync/sync_process.py
@@ -39,6 +39,7 @@ from neptune_scale.exceptions import (
     NeptuneConnectionLostError,
     NeptuneInternalServerError,
     NeptuneOperationsQueueMaxSizeExceeded,
+    NeptunePreviewStepNotAfterLastCommittedStep,
     NeptuneProjectInvalidName,
     NeptuneProjectNotFound,
     NeptuneRetryableError,
@@ -58,7 +59,6 @@ from neptune_scale.exceptions import (
     NeptuneUnauthorizedError,
     NeptuneUnexpectedError,
     NeptuneUnexpectedResponseError,
-    NeptunePreviewStepNotAfterLastCommittedStep,
 )
 from neptune_scale.net.api_client import (
     ApiClient,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -51,8 +51,8 @@ class SyncRun(Run):
     after each logging method call. This is useful for e2e tests, where we
     usually want to wait for the data to be available before fetching it."""
 
-    def log(self, *args, **kwargs):
-        result = super().log(*args, **kwargs)
+    def _log(self, *args, **kwargs):
+        result = super()._log(*args, **kwargs)
         self.wait_for_processing()
         return result
 

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -1,6 +1,10 @@
-from datetime import datetime
-from unittest.mock import Mock
+from datetime import (
+    datetime,
+    timedelta,
+)
+from unittest.mock import call, Mock
 
+from freezegun import freeze_time
 import pytest
 from pytest import (
     fixture,
@@ -8,6 +12,7 @@ from pytest import (
 )
 
 from neptune_scale.api.attribute import cleanup_path
+from neptune_scale.api.metrics import Metrics
 from neptune_scale.legacy import Run
 
 
@@ -66,12 +71,44 @@ def test_tags(run, store):
     store.log.assert_called_with(tags_remove={"sys/tags": ("tag1", "tag2")})
 
 
-def test_series(run, store):
+def test_append(run, store):
     run["sys/series"].append(1, step=1, timestamp=10)
-    store.log.assert_called_with(metrics={"sys/series": 1}, step=1, timestamp=10)
+    store.log.assert_called_with(metrics=Metrics(data={"sys/series": 1}, step=1), timestamp=10)
 
     run["sys/series"].append({"foo": 1, "bar": 2}, step=2)
-    store.log.assert_called_with(metrics={"sys/series/foo": 1, "sys/series/bar": 2}, step=2, timestamp=None)
+    store.log.assert_called_with(metrics=Metrics(data={"sys/series/foo": 1, "sys/series/bar": 2}, step=2), timestamp=None)
+
+    run["my/series"].append({"foo": 1, "bar": 2}, step=3, preview=True, preview_completion=0.3)
+    store.log.assert_called_with(
+            metrics=Metrics(data={"my/series/foo": 1, "my/series/bar": 2}, step=3, preview=True, preview_completion=0.3),
+            timestamp=None)
+
+
+@freeze_time("2024-07-30 12:12:12.000022")
+def test_extend(run, store):
+    now = datetime.now()
+    before = now - timedelta(seconds=1)
+
+    run["my/series"].extend([1,2], steps=[1,2], timestamps=[before, now])
+    store.log.assert_has_calls([
+            call(metrics=Metrics(data={"my/series": 1}, step=1), timestamp=before),
+            call(metrics=Metrics(data={"my/series": 2}, step=2), timestamp=now)])
+
+    # timestamp defaulting
+    run["my/series"].extend([3,4], steps=[3,4])
+    store.log.assert_has_calls([
+            call(metrics=Metrics(data={"my/series": 3}, step=3), timestamp=now),
+            call(metrics=Metrics(data={"my/series": 4}, step=4), timestamp=now)])
+
+    # previews
+    run["my/series"].extend([5,6], steps=[5,6], previews=[False, True], preview_completions=[0.0, 0.5], timestamps=[now,now])
+    store.log.assert_has_calls([
+            call(metrics=Metrics(data={"my/series": 5}, step=5), timestamp=now),
+            call(metrics=Metrics(data={"my/series": 6}, step=6, preview=True, preview_completion=0.5), timestamp=now)])
+
+    # different length of inputs
+    with pytest.raises(ValueError):
+        run["my/series"].extend([7], steps=[7,8])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -72,8 +72,8 @@ def test_tags(run, store):
 
 
 def test_append(run, store):
-    run["sys/series"].append(1, step=1, timestamp=10)
-    store.log.assert_called_with(metrics=Metrics(data={"sys/series": 1}, step=1), timestamp=10)
+    run["sys/series"].append(3, step=1, timestamp=10)
+    store.log.assert_called_with(metrics=Metrics(data={"sys/series": 3}, step=1), timestamp=10)
 
     run["sys/series"].append({"foo": 1, "bar": 2}, step=2)
     store.log.assert_called_with(metrics=Metrics(data={"sys/series/foo": 1, "sys/series/bar": 2}, step=2), timestamp=None)
@@ -89,22 +89,22 @@ def test_extend(run, store):
     now = datetime.now()
     before = now - timedelta(seconds=1)
 
-    run["my/series"].extend([1,2], steps=[1,2], timestamps=[before, now])
+    run["my/series"].extend([7,38], steps=[1,2], timestamps=[before, now])
     store.log.assert_has_calls([
-            call(metrics=Metrics(data={"my/series": 1}, step=1), timestamp=before),
-            call(metrics=Metrics(data={"my/series": 2}, step=2), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 7}, step=1), timestamp=before),
+            call(metrics=Metrics(data={"my/series": 38}, step=2), timestamp=now)])
 
     # timestamp defaulting
-    run["my/series"].extend([3,4], steps=[3,4])
+    run["my/series"].extend([7,38], steps=[3,4])
     store.log.assert_has_calls([
-            call(metrics=Metrics(data={"my/series": 3}, step=3), timestamp=now),
-            call(metrics=Metrics(data={"my/series": 4}, step=4), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 7}, step=3), timestamp=now),
+            call(metrics=Metrics(data={"my/series": 38}, step=4), timestamp=now)])
 
     # previews
-    run["my/series"].extend([5,6], steps=[5,6], previews=[False, True], preview_completions=[0.0, 0.5], timestamps=[now,now])
+    run["my/series"].extend([7,38], steps=[5,6], previews=[False, True], preview_completions=[0.0, 0.5], timestamps=[now,now])
     store.log.assert_has_calls([
-            call(metrics=Metrics(data={"my/series": 5}, step=5), timestamp=now),
-            call(metrics=Metrics(data={"my/series": 6}, step=6, preview=True, preview_completion=0.5), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 7}, step=5, preview=False, preview_completion=0.0), timestamp=now),
+            call(metrics=Metrics(data={"my/series": 38}, step=6, preview=True, preview_completion=0.5), timestamp=now)])
 
     # different length of inputs
     with pytest.raises(ValueError):

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -2,10 +2,13 @@ from datetime import (
     datetime,
     timedelta,
 )
-from unittest.mock import call, Mock
+from unittest.mock import (
+    Mock,
+    call,
+)
 
-from freezegun import freeze_time
 import pytest
+from freezegun import freeze_time
 from pytest import (
     fixture,
     mark,
@@ -76,12 +79,15 @@ def test_append(run, store):
     store.log.assert_called_with(metrics=Metrics(data={"sys/series": 3}, step=1), timestamp=10)
 
     run["sys/series"].append({"foo": 1, "bar": 2}, step=2)
-    store.log.assert_called_with(metrics=Metrics(data={"sys/series/foo": 1, "sys/series/bar": 2}, step=2), timestamp=None)
+    store.log.assert_called_with(
+        metrics=Metrics(data={"sys/series/foo": 1, "sys/series/bar": 2}, step=2), timestamp=None
+    )
 
     run["my/series"].append({"foo": 1, "bar": 2}, step=3, preview=True, preview_completion=0.3)
     store.log.assert_called_with(
-            metrics=Metrics(data={"my/series/foo": 1, "my/series/bar": 2}, step=3, preview=True, preview_completion=0.3),
-            timestamp=None)
+        metrics=Metrics(data={"my/series/foo": 1, "my/series/bar": 2}, step=3, preview=True, preview_completion=0.3),
+        timestamp=None,
+    )
 
 
 @freeze_time("2024-07-30 12:12:12.000022")
@@ -89,26 +95,37 @@ def test_extend(run, store):
     now = datetime.now()
     before = now - timedelta(seconds=1)
 
-    run["my/series"].extend([7,38], steps=[1,2], timestamps=[before, now])
-    store.log.assert_has_calls([
+    run["my/series"].extend([7, 38], steps=[1, 2], timestamps=[before, now])
+    store.log.assert_has_calls(
+        [
             call(metrics=Metrics(data={"my/series": 7}, step=1), timestamp=before),
-            call(metrics=Metrics(data={"my/series": 38}, step=2), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 38}, step=2), timestamp=now),
+        ]
+    )
 
     # timestamp defaulting
-    run["my/series"].extend([7,38], steps=[3,4])
-    store.log.assert_has_calls([
+    run["my/series"].extend([7, 38], steps=[3, 4])
+    store.log.assert_has_calls(
+        [
             call(metrics=Metrics(data={"my/series": 7}, step=3), timestamp=now),
-            call(metrics=Metrics(data={"my/series": 38}, step=4), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 38}, step=4), timestamp=now),
+        ]
+    )
 
     # previews
-    run["my/series"].extend([7,38], steps=[5,6], previews=[False, True], preview_completions=[1.0, 0.5], timestamps=[now,now])
-    store.log.assert_has_calls([
+    run["my/series"].extend(
+        [7, 38], steps=[5, 6], previews=[False, True], preview_completions=[1.0, 0.5], timestamps=[now, now]
+    )
+    store.log.assert_has_calls(
+        [
             call(metrics=Metrics(data={"my/series": 7}, step=5, preview=False, preview_completion=None), timestamp=now),
-            call(metrics=Metrics(data={"my/series": 38}, step=6, preview=True, preview_completion=0.5), timestamp=now)])
+            call(metrics=Metrics(data={"my/series": 38}, step=6, preview=True, preview_completion=0.5), timestamp=now),
+        ]
+    )
 
     # different length of inputs
     with pytest.raises(ValueError):
-        run["my/series"].extend([7], steps=[7,8])
+        run["my/series"].extend([7], steps=[7, 8])
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_attribute.py
+++ b/tests/unit/test_attribute.py
@@ -101,9 +101,9 @@ def test_extend(run, store):
             call(metrics=Metrics(data={"my/series": 38}, step=4), timestamp=now)])
 
     # previews
-    run["my/series"].extend([7,38], steps=[5,6], previews=[False, True], preview_completions=[0.0, 0.5], timestamps=[now,now])
+    run["my/series"].extend([7,38], steps=[5,6], previews=[False, True], preview_completions=[1.0, 0.5], timestamps=[now,now])
     store.log.assert_has_calls([
-            call(metrics=Metrics(data={"my/series": 7}, step=5, preview=False, preview_completion=0.0), timestamp=now),
+            call(metrics=Metrics(data={"my/series": 7}, step=5, preview=False, preview_completion=None), timestamp=now),
             call(metrics=Metrics(data={"my/series": 38}, step=6, preview=True, preview_completion=0.5), timestamp=now)])
 
     # different length of inputs

--- a/tests/unit/test_integration_batching.py
+++ b/tests/unit/test_integration_batching.py
@@ -1,14 +1,13 @@
-from datetime import datetime
 import threading
+from datetime import datetime
 
+import pytest
 from freezegun import freeze_time
 from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
     Preview,
     UpdateRunSnapshot,
-    Value,
 )
 from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
-import pytest
 
 from neptune_scale.api.attribute import AttributeStore
 from neptune_scale.api.metrics import Metrics
@@ -17,39 +16,44 @@ from neptune_scale.net.serialization import (
     make_step,
     make_value,
 )
-from neptune_scale.sync.operations_queue import OperationsQueue
 from neptune_scale.sync.aggregating_queue import AggregatingQueue
-from neptune_scale.sync.queue_element import SingleOperation
+from neptune_scale.sync.operations_queue import OperationsQueue
 
 
 @pytest.mark.parametrize(
     "metrics,expected_updates",
     [
-        pytest.param([
-                Metrics(data={"x":1, "y":5}, step=1),
-                Metrics(data={"a":2}, step=1),
-            ],[
-                {"step": 1, "append":{"a": 2, "x": 1, "y": 5}},
+        pytest.param(
+            [
+                Metrics(data={"x": 1, "y": 5}, step=1),
+                Metrics(data={"a": 2}, step=1),
+            ],
+            [
+                {"step": 1, "append": {"a": 2, "x": 1, "y": 5}},
             ],
             id="Different metrics, same step",
         ),
-        pytest.param([
-                Metrics(data={"a":1, "b":2}, step=1),
-                Metrics(data={"a":2}, step=2),
-            ],[
-                {"step": 1, "append":{"a": 1, "b": 2}},
-                {"step": 2, "append":{"a": 2}},
+        pytest.param(
+            [
+                Metrics(data={"a": 1, "b": 2}, step=1),
+                Metrics(data={"a": 2}, step=2),
+            ],
+            [
+                {"step": 1, "append": {"a": 1, "b": 2}},
+                {"step": 2, "append": {"a": 2}},
             ],
             id="Different step",
         ),
-        pytest.param([
-                Metrics(data={"a":1, "b":2}, step=1, preview=True, preview_completion=0.2),
-                Metrics(data={"a":10, "b":20}, step=1, preview=True, preview_completion=0.8),
-                Metrics(data={"a":100, "b":200}, step=1),
-            ],[
-                {"step": 1, "append":{"a": 1, "b": 2}, "preview": True, "preview_completion": 0.2},
-                {"step": 1, "append":{"a": 10, "b": 20}, "preview": True, "preview_completion": 0.8},
-                {"step": 1, "append":{"a": 100, "b": 200}},
+        pytest.param(
+            [
+                Metrics(data={"a": 1, "b": 2}, step=1, preview=True, preview_completion=0.2),
+                Metrics(data={"a": 10, "b": 20}, step=1, preview=True, preview_completion=0.8),
+                Metrics(data={"a": 100, "b": 200}, step=1),
+            ],
+            [
+                {"step": 1, "append": {"a": 1, "b": 2}, "preview": True, "preview_completion": 0.2},
+                {"step": 1, "append": {"a": 10, "b": 20}, "preview": True, "preview_completion": 0.8},
+                {"step": 1, "append": {"a": 100, "b": 200}},
             ],
             id="Multiple previews for same point",
         ),
@@ -78,11 +82,15 @@ def test__merge_metrics(metrics, expected_updates):
     results = batch.update_batch.snapshots if batch.update_batch.snapshots else [batch.update]
     assert len(results) == len(expected_updates)
     for expected in expected_updates:
-        preview = Preview(is_preview=expected["preview"], completion_ratio=expected.get("preview_completion", 0.0)) if "preview" in expected else None
+        preview = (
+            Preview(is_preview=expected["preview"], completion_ratio=expected.get("preview_completion", 0.0))
+            if "preview" in expected
+            else None
+        )
         exp_proto = UpdateRunSnapshot(
             step=make_step(expected.get("step")),
             timestamp=datetime_to_proto(datetime.now()),
-            append={k: make_value(float(v)) for k,v in expected.get("append", {}).items()},
+            append={k: make_value(float(v)) for k, v in expected.get("append", {}).items()},
             preview=preview,
         )
         for got in results:

--- a/tests/unit/test_integration_batching.py
+++ b/tests/unit/test_integration_batching.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+import threading
+
+from freezegun import freeze_time
+from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
+    Preview,
+    UpdateRunSnapshot,
+    Value,
+)
+from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
+import pytest
+
+from neptune_scale.api.attribute import AttributeStore
+from neptune_scale.api.metrics import Metrics
+from neptune_scale.net.serialization import (
+    datetime_to_proto,
+    make_step,
+    make_value,
+)
+from neptune_scale.sync.operations_queue import OperationsQueue
+from neptune_scale.sync.aggregating_queue import AggregatingQueue
+from neptune_scale.sync.queue_element import SingleOperation
+
+
+@pytest.mark.parametrize(
+    "metrics,expected_updates",
+    [
+        pytest.param([
+                Metrics(data={"x":1, "y":5}, step=1),
+                Metrics(data={"a":2}, step=1),
+            ],[
+                {"step": 1, "append":{"a": 2, "x": 1, "y": 5}},
+            ],
+            id="Different metrics, same step",
+        ),
+        pytest.param([
+                Metrics(data={"a":1, "b":2}, step=1),
+                Metrics(data={"a":2}, step=2),
+            ],[
+                {"step": 1, "append":{"a": 1, "b": 2}},
+                {"step": 2, "append":{"a": 2}},
+            ],
+            id="Different step",
+        ),
+        pytest.param([
+                Metrics(data={"a":1, "b":2}, step=1, preview=True, preview_completion=0.2),
+                Metrics(data={"a":10, "b":20}, step=1, preview=True, preview_completion=0.8),
+                Metrics(data={"a":100, "b":200}, step=1),
+            ],[
+                {"step": 1, "append":{"a": 1, "b": 2}, "preview": True, "preview_completion": 0.2},
+                {"step": 1, "append":{"a": 10, "b": 20}, "preview": True, "preview_completion": 0.8},
+                {"step": 1, "append":{"a": 100, "b": 200}},
+            ],
+            id="Multiple previews for same point",
+        ),
+    ],
+)
+@freeze_time("2025-02-01")
+def test__merge_metrics(metrics, expected_updates):
+    # given
+    op_queue = OperationsQueue(lock=threading.RLock(), max_size=1000)
+    store = AttributeStore("project", "run_id", op_queue)
+    agg_queue = AggregatingQueue(1000)
+
+    # when
+    for m in metrics:
+        store.log(metrics=m)
+        agg_queue.put_nowait(op_queue.queue.get())
+
+    result = agg_queue.get()
+    batch = RunOperation()
+    batch.ParseFromString(result.operation)
+
+    # then
+    assert batch.project == "project"
+    assert batch.run_id == "run_id"
+
+    results = batch.update_batch.snapshots if batch.update_batch.snapshots else [batch.update]
+    assert len(results) == len(expected_updates)
+    for expected in expected_updates:
+        preview = Preview(is_preview=expected["preview"], completion_ratio=expected.get("preview_completion", 0.0)) if "preview" in expected else None
+        exp_proto = UpdateRunSnapshot(
+            step=make_step(expected.get("step")),
+            timestamp=datetime_to_proto(datetime.now()),
+            append={k: make_value(float(v)) for k,v in expected.get("append", {}).items()},
+            preview=preview,
+        )
+        for got in results:
+            if got == exp_proto:
+                break
+        else:
+            pytest.fail(f"didn't find expected result: {exp_proto}")

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -94,7 +94,7 @@ def test_configs():
 
 @freeze_time("2024-07-30 12:12:12.000022")
 @pytest.mark.parametrize(
-    "preview,preview_completion,expected_proto",
+    "preview,preview_completion,expected_preview_proto",
     [
         pytest.param(
             False, None, None, id="no preview",
@@ -110,7 +110,7 @@ def test_configs():
         ),
     ],
 )
-def test_metrics(preview, preview_completion, expected_proto):
+def test_metrics(preview, preview_completion, expected_preview_proto):
     # given
     metrics = Metrics(
         step=1,
@@ -143,7 +143,7 @@ def test_metrics(preview, preview_completion, expected_proto):
     expected_update = UpdateRunSnapshot(
         step=Step(whole=1, micro=0),
         timestamp=Timestamp(seconds=1722341532, nanos=21934),
-        preview=expected_proto,
+        preview=expected_preview_proto,
         append={
             "some/metric": Value(float64=3.14),
         },

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -44,9 +44,7 @@ def test_empty():
     # then
     assert len(result) == 1
     operation, metadata_size = result[0]
-    expected_update = UpdateRunSnapshot(
-        timestamp=Timestamp(seconds=1722341532, nanos=21934)
-    )
+    expected_update = UpdateRunSnapshot(timestamp=Timestamp(seconds=1722341532, nanos=21934))
     assert operation == RunOperation(project="workspace/project", run_id="run_id", update=expected_update)
     assert metadata_size == expected_update.ByteSize()
 
@@ -92,21 +90,34 @@ def test_configs():
     assert metadata_size >= expected_update.ByteSize()
     assert metadata_size < operation.ByteSize()
 
+
 @freeze_time("2024-07-30 12:12:12.000022")
 @pytest.mark.parametrize(
     "preview,preview_completion,expected_preview_proto",
     [
         pytest.param(
-            False, None, None, id="no preview",
+            False,
+            None,
+            None,
+            id="no preview",
         ),
         pytest.param(
-            False, 0.5, None, id="no preview, preview_completion ignored",
+            False,
+            0.5,
+            None,
+            id="no preview, preview_completion ignored",
         ),
         pytest.param(
-            True, None, Preview(is_preview=True), id="preview with no explicit completion",
+            True,
+            None,
+            Preview(is_preview=True),
+            id="preview with no explicit completion",
         ),
         pytest.param(
-            True, 0.5, Preview(is_preview=True, completion_ratio=0.5), id="preview with specified completion",
+            True,
+            0.5,
+            Preview(is_preview=True, completion_ratio=0.5),
+            id="preview with specified completion",
         ),
     ],
 )
@@ -311,7 +322,7 @@ def test_raise_on_non_finite_float_metrics(value):
 
     # when
     with pytest.raises(NeptuneFloatValueNanInfUnsupported) as exc:
-        builder = MetadataSplitter(
+        MetadataSplitter(
             project="workspace/project",
             run_id="run_id",
             timestamp=datetime.now(),

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -11,6 +11,7 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
     SET_OPERATION,
     ModifySet,
     ModifyStringSet,
+    Preview,
     Step,
     StringSet,
     UpdateRunSnapshot,
@@ -19,6 +20,7 @@ from neptune_api.proto.neptune_pb.ingest.v1.common_pb2 import (
 from neptune_api.proto.neptune_pb.ingest.v1.pub.ingest_pb2 import RunOperation
 from pytest import mark
 
+from neptune_scale.api.metrics import Metrics
 from neptune_scale.exceptions import NeptuneFloatValueNanInfUnsupported
 from neptune_scale.sync.metadata_splitter import MetadataSplitter
 
@@ -29,10 +31,9 @@ def test_empty():
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=datetime.now(),
         configs={},
-        metrics={},
+        metrics=None,
         add_tags={},
         remove_tags={},
     )
@@ -44,7 +45,7 @@ def test_empty():
     assert len(result) == 1
     operation, metadata_size = result[0]
     expected_update = UpdateRunSnapshot(
-        step=Step(whole=1, micro=0), timestamp=Timestamp(seconds=1722341532, nanos=21934)
+        timestamp=Timestamp(seconds=1722341532, nanos=21934)
     )
     assert operation == RunOperation(project="workspace/project", run_id="run_id", update=expected_update)
     assert metadata_size == expected_update.ByteSize()
@@ -56,7 +57,6 @@ def test_configs():
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=datetime.now(),
         configs={
             "some/string": "value",
@@ -66,7 +66,7 @@ def test_configs():
             "some/datetime": datetime.now(),
             "some/tags": {"tag1", "tag2"},
         },
-        metrics={},
+        metrics=None,
         add_tags={},
         remove_tags={},
     )
@@ -78,7 +78,6 @@ def test_configs():
     assert len(result) == 1
     operation, metadata_size = result[0]
     expected_update = UpdateRunSnapshot(
-        step=Step(whole=1, micro=0),
         timestamp=Timestamp(seconds=1722341532, nanos=21934),
         assign={
             "some/string": Value(string="value"),
@@ -93,19 +92,44 @@ def test_configs():
     assert metadata_size >= expected_update.ByteSize()
     assert metadata_size < operation.ByteSize()
 
-
 @freeze_time("2024-07-30 12:12:12.000022")
-def test_metrics():
+@pytest.mark.parametrize(
+    "preview,preview_completion,expected_proto",
+    [
+        pytest.param(
+            False, None, None, id="no preview",
+        ),
+        pytest.param(
+            False, 0.5, None, id="no preview, preview_completion ignored",
+        ),
+        pytest.param(
+            True, None, Preview(is_preview=True), id="preview with no explicit completion",
+        ),
+        pytest.param(
+            True, 0.5, Preview(is_preview=True, completion_ratio=0.5), id="preview with specified completion",
+        ),
+    ],
+)
+def test_metrics(preview, preview_completion, expected_proto):
     # given
+    metrics = Metrics(
+        step=1,
+        data={
+            "some/metric": 3.14,
+        },
+        preview=preview,
+    )
+    if preview_completion is not None:
+        metrics.preview_completion = preview_completion
+
+    # and
+
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=datetime.now(),
         configs={},
-        metrics={
-            "some/metric": 3.14,
-        },
+        metrics=metrics,
         add_tags={},
         remove_tags={},
     )
@@ -119,6 +143,7 @@ def test_metrics():
     expected_update = UpdateRunSnapshot(
         step=Step(whole=1, micro=0),
         timestamp=Timestamp(seconds=1722341532, nanos=21934),
+        preview=expected_proto,
         append={
             "some/metric": Value(float64=3.14),
         },
@@ -134,10 +159,9 @@ def test_tags():
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=datetime.now(),
         configs={},
-        metrics={},
+        metrics=None,
         add_tags={
             "some/tags": {"tag1", "tag2"},
             "some/other_tags2": {"tag2", "tag3"},
@@ -155,7 +179,6 @@ def test_tags():
     assert len(result) == 1
     operation, metadata_size = result[0]
     expected_update = UpdateRunSnapshot(
-        step=Step(whole=1, micro=0),
         timestamp=Timestamp(seconds=1722341532, nanos=21934),
         modify_sets={
             "some/tags": ModifySet(
@@ -182,16 +205,19 @@ def test_splitting():
     # given
     max_size = 1024
     timestamp = datetime.now()
-    metrics = {f"metric{v}": 7 / 9.0 * v for v in range(1000)}
     configs = {f"config{v}": v for v in range(1000)}
     add_tags = {f"add/tag{v}": {f"value{v}"} for v in range(1000)}
     remove_tags = {f"remove/tag{v}": {f"value{v}"} for v in range(1000)}
+    metrics = Metrics(
+        step=1,
+        data={f"metric{v}": 7 / 9.0 * v for v in range(1000)},
+        preview=True,
+    )
 
     # and
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=timestamp,
         configs=configs,
         metrics=metrics,
@@ -213,10 +239,11 @@ def test_splitting():
     assert all(op.project == "workspace/project" for op, _ in result)
     assert all(op.run_id == "run_id" for op, _ in result)
     assert all(op.update.step.whole == 1 for op, _ in result)
+    assert all(op.update.preview.is_preview if len(op.update.append) > 0 else True for op, _ in result)
     assert all(op.update.timestamp == Timestamp(seconds=1722341532, nanos=21934) for op, _ in result)
 
     # Check if all metrics, configs and tags are present in the result
-    assert sorted([key for op, _ in result for key in op.update.append.keys()]) == sorted(list(metrics.keys()))
+    assert sorted([key for op, _ in result for key in op.update.append.keys()]) == sorted(list(metrics.data.keys()))
     assert sorted([key for op, _ in result for key in op.update.assign.keys()]) == sorted(list(configs.keys()))
     assert sorted([key for op, _ in result for key in op.update.modify_sets.keys()]) == sorted(
         list(add_tags.keys()) + list(remove_tags.keys())
@@ -228,7 +255,7 @@ def test_split_large_tags():
     # given
     max_size = 1024
     timestamp = datetime.now()
-    metrics = {}
+    metrics = None
     fields = {}
     add_tags = {"add/tag": {f"value{v}" for v in range(1000)}}
     remove_tags = {"remove/tag": {f"value{v}" for v in range(1000)}}
@@ -237,7 +264,6 @@ def test_split_large_tags():
     builder = MetadataSplitter(
         project="workspace/project",
         run_id="run_id",
-        step=1,
         timestamp=timestamp,
         configs=fields,
         metrics=metrics,
@@ -258,7 +284,6 @@ def test_split_large_tags():
     # Common metadata
     assert all(op.project == "workspace/project" for op, _ in result)
     assert all(op.run_id == "run_id" for op, _ in result)
-    assert all(op.update.step.whole == 1 for op, _ in result)
     assert all(op.update.timestamp == Timestamp(seconds=1722341532, nanos=21934) for op, _ in result)
 
     # Check if all StringSet values are split correctly
@@ -278,21 +303,26 @@ def test_split_large_tags():
 @patch.dict(os.environ, {"NEPTUNE_SKIP_NON_FINITE_METRICS": "False"})
 @mark.parametrize("value", [np.inf, -np.inf, np.nan, math.inf, -math.inf, math.nan])
 def test_raise_on_non_finite_float_metrics(value):
-    builder = MetadataSplitter(
-        project="workspace/project",
-        run_id="run_id",
+    # given
+    metrics = Metrics(
         step=10,
-        timestamp=datetime.now(),
-        configs={},
-        metrics={"bad-metric": value},
-        add_tags={},
-        remove_tags={},
-        max_message_bytes_size=1024,
+        data={"bad-metric": value},
     )
 
+    # when
     with pytest.raises(NeptuneFloatValueNanInfUnsupported) as exc:
-        list(builder)
+        builder = MetadataSplitter(
+            project="workspace/project",
+            run_id="run_id",
+            timestamp=datetime.now(),
+            configs={},
+            metrics=metrics,
+            add_tags={},
+            remove_tags={},
+            max_message_bytes_size=1024,
+        )
 
+    # then
     exc.match("metric `bad-metric`")
     exc.match("step `10`")
     exc.match(f"non-finite value of `{value}`")
@@ -301,21 +331,28 @@ def test_raise_on_non_finite_float_metrics(value):
 @mark.parametrize("value", [np.inf, -np.inf, np.nan, math.inf, -math.inf, math.nan])
 def test_skip_non_finite_float_metrics(value, caplog):
     with caplog.at_level("WARNING"):
+        # given
+        metrics = Metrics(
+            step=10,
+            data={"bad-metric": value},
+        )
+
+        # when
         builder = MetadataSplitter(
             project="workspace/project",
             run_id="run_id",
-            step=10,
             timestamp=datetime.now(),
             configs={},
-            metrics={"bad-metric": value},
+            metrics=metrics,
             add_tags={},
             remove_tags={},
             max_message_bytes_size=1024,
         )
 
         result = list(builder)
-        assert len(result) == 1
 
+        # then
+        assert len(result) == 1
         op, _ = result[0]
         assert not op.update.assign
 


### PR DESCRIPTION
Also includes a minor internal refactor, wrapping all metric-specific data & metadata into a dataclass.

Docs will follow-up in the next commit (ie. not included yet).

Note: This uses proto fields added in https://github.com/neptune-ai/neptune-api/pull/55 and will not work until that dependency is bumped.

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
