### PR TITLE
chore: remove AUTOINCREMENT from operations repo DDL

### DIFF
--- a/src/neptune_scale/sync/operations_repository.py
+++ b/src/neptune_scale/sync/operations_repository.py
@@ -92,7 +92,7 @@ class OperationsRepository:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS run_operations (
-                    sequence_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sequence_id INTEGER PRIMARY KEY,
                     timestamp INTEGER NOT NULL,
                     operation_type INTEGER NOT NULL,
                     operation BLOB NOT NULL,
@@ -103,7 +103,7 @@ class OperationsRepository:
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS metadata (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    id INTEGER PRIMARY KEY,
                     version TEXT NOT NULL,
                     project TEXT NOT NULL,
                     run_id TEXT NOT NULL


### PR DESCRIPTION
AUTOINCREMENT is unnecessary if we assume that we never reach sequence_id == 9223372036854775807 and it has some overhead
https://www.sqlite.org/autoinc.html