### PR TITLE
fix: Add index to SQLite to improve retrieval

### DIFF
--- a/src/neptune_scale/sync/operations_repository.py
+++ b/src/neptune_scale/sync/operations_repository.py
@@ -393,6 +393,7 @@ class OperationsRepository:
                 )
 
                 self._connection.execute("PRAGMA journal_mode = WAL")
+                self._connection.execute("PRAGMA synchronous = FULL")
 
                 logger.debug(f"Created new SQLite connection for {self._db_path}")
 


### PR DESCRIPTION
This PR changes 3 things:
1. It introduces an index that allows efficient querying of operation sizes
2. It moves operations deserialization outside of the retrieval transaction (which is important, as holding a read lock prevents full WAL checkpointing)
3. It sets `PRAGMA synchronous = FULL` for connections which enforces durability of transactions. See https://www.sqlite.org/pragma.html#pragma_synchronous