### PR TITLE
Print the correct operation count in `Run._wait()`

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -669,7 +669,7 @@ class Run(AbstractContextManager):
                     if last_queued_sequence_id != -1:
                         last_print_timestamp = print_message(
                             f"Waiting. No operations were {phrase} yet. Operations to sync: %s",
-                            last_queued_sequence_id + 1,
+                            last_queued_sequence_id,
                             last_print=last_print_timestamp,
                             verbose=verbose,
                         )
@@ -682,7 +682,7 @@ class Run(AbstractContextManager):
                 elif value < last_queued_sequence_id:
                     last_print_timestamp = print_message(
                         f"Waiting for remaining %d operation(s) to be {phrase}",
-                        last_queued_sequence_id - value + 1,
+                        last_queued_sequence_id - value,
                         last_print=last_print_timestamp,
                         verbose=verbose,
                     )


### PR DESCRIPTION
Since the first operation sequence is 1, we don't need to add +1 in logging output
