### PR TITLE
Introduce `NEPTUNE_LOGGER_LEVEL`. Deprecate `NEPTUNE_DEBUG_MODE`.

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -608,7 +608,6 @@ class Run(AbstractContextManager):
             return
 
         if self._attr_store is None:
-            logger.debug("Run is in mode that doesn't support logging.")
             return
 
         self._attr_store.log(

--- a/src/neptune_scale/sync/errors_tracking.py
+++ b/src/neptune_scale/sync/errors_tracking.py
@@ -30,6 +30,7 @@ class ErrorsQueue:
         self._errors_queue: multiprocessing.Queue[BaseException] = multiprocessing.Queue()
 
     def put(self, error: BaseException) -> None:
+        logger.debug("Put error: %s", type(error))
         self._errors_queue.put(error)
 
     def get(self, block: bool = True, timeout: Optional[float] = None) -> BaseException:

--- a/src/neptune_scale/util/daemon.py
+++ b/src/neptune_scale/util/daemon.py
@@ -25,7 +25,7 @@ class Daemon(threading.Thread):
         self._wait_condition = threading.Condition()
 
     def interrupt(self) -> None:
-        logger.debug(f"Thread {self} interrupted.")
+        logger.debug(f"Interrupting thread {self.name}")
         with self._wait_condition:
             self._state = Daemon.DaemonState.INTERRUPTED
             self._wait_condition.notify_all()
@@ -85,7 +85,7 @@ class Daemon(threading.Thread):
                 self._state = Daemon.DaemonState.STOPPED
                 self._wait_condition.notify_all()
 
-            logger.debug(f"Thread {self} is finished.")
+            logger.debug(f"Thread {self.name} is finished.")
 
     @abc.abstractmethod
     def work(self) -> None: ...

--- a/src/neptune_scale/util/envs.py
+++ b/src/neptune_scale/util/envs.py
@@ -7,7 +7,11 @@ API_TOKEN_ENV_NAME = "NEPTUNE_API_TOKEN"
 
 DISABLE_COLORS = "NEPTUNE_DISABLE_COLORS"
 
+# Deprecated in favour of NEPTUNE_LOGGER_LEVEL
 DEBUG_MODE = "NEPTUNE_DEBUG_MODE"
+
+# Logging level for the neptune logger. Valid values: "debug", "info", "warning", "error", "critical", "none".
+LOGGER_LEVEL = "NEPTUNE_LOGGER_LEVEL"
 
 SUBPROCESS_KILL_TIMEOUT = "NEPTUNE_SUBPROCESS_KILL_TIMEOUT"
 

--- a/src/neptune_scale/util/logger.py
+++ b/src/neptune_scale/util/logger.py
@@ -1,9 +1,14 @@
 __all__ = ("get_logger",)
 
 import logging
+import os
+import warnings
+from typing import Optional
 
-from neptune_scale.util import envs
-from neptune_scale.util.envs import DEBUG_MODE
+from neptune_scale.util.envs import (
+    DEBUG_MODE,
+    LOGGER_LEVEL,
+)
 from neptune_scale.util.styles import (
     STYLES,
     ensure_style_detected,
@@ -13,8 +18,11 @@ from neptune_scale.util.styles import (
 class NeptuneWarning(Warning): ...
 
 
-LOG_FORMAT = "%(asctime)s {blue}%(name)s{end}:{bold}%(levelname)s{end}: %(message)s"
-DEBUG_FORMAT = "%(asctime)s:%(name)s:%(levelname)s:%(processName)s/%(threadName)s/%(funcName)s: %(message)s"
+DEFAULT_FORMAT = "%(asctime)s {blue}%(name)s{end}:{bold}%(levelname)s{end}: %(message)s"
+DEBUG_FORMAT = (
+    "%(asctime)s {blue}%(name)s{end}:{bold}%(levelname)s{end}:"
+    "{blue}%(processName)s/%(threadName)s/%(funcName)s{end}: %(message)s"
+)
 
 
 def get_logger() -> logging.Logger:
@@ -34,14 +42,46 @@ def get_logger() -> logging.Logger:
 
     ensure_style_detected()
 
-    debug = envs.get_bool(DEBUG_MODE, False)
-    logger.setLevel(logging.DEBUG if debug else logging.INFO)
+    if logger_level := _logger_level_from_env():
+        log_format = DEBUG_FORMAT if logger_level == "DEBUG" else DEFAULT_FORMAT
 
-    stream_handler = logging.StreamHandler()
-    log_format = DEBUG_FORMAT if debug else LOG_FORMAT.format(**STYLES)
-    stream_handler.setFormatter(logging.Formatter(log_format))
-    logger.addHandler(stream_handler)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(logging.Formatter(log_format.format(**STYLES)))
+        logger.addHandler(stream_handler)
+        logger.setLevel(logger_level)
+    else:
+        logger.disabled = True
 
     logger.__neptune_scale = True  # type: ignore
 
     return logger
+
+
+# Does not include "none", as it's a special case that is not supported by the `logging` module.
+_valid_levels = ("debug", "info", "warning", "error", "critical")
+
+
+def _logger_level_from_env() -> Optional[str]:
+    """Return logger level as str that can be used with logging module or None if logging is disabled.
+    Reads both NEPTUNE_DEBUG_MODE and NEPTUNE_LOGGER_LEVEL, with the latter taking precedence.
+    """
+
+    default_level = "info"
+
+    debug_mode = os.environ.get(DEBUG_MODE)
+    if debug_mode is not None:
+        warnings.warn(
+            f"{DEBUG_MODE} is deprecated and will be removed in a future release. Use {LOGGER_LEVEL} instead.",
+            FutureWarning,
+        )
+
+        default_level = "debug" if debug_mode.lower() in ("true", "1") else "info"
+
+    level = os.getenv(LOGGER_LEVEL, default_level)
+    if level == "none":
+        return None
+
+    if level not in _valid_levels:
+        raise ValueError(f"{LOGGER_LEVEL} must be one of: none, {', '.join(_valid_levels)}.")
+
+    return level.upper()


### PR DESCRIPTION
* `NEPTUNE_DEBUG_MODE` is now deprecated
* `NEPTUNE_LOGGER_LEVEL` is used instead
  * valid values: `debug, info, warning, error, critical, and none`.
  * `none` is a special value that disables the neptune logger
* debugging output is longer logged to a file, but stderr instead
* clean up some `logging.debug()` calls for clarity
