### PR TITLE
feat: add timeout to close and sync

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -938,9 +938,6 @@ class Run(AbstractContextManager):
             except KeyboardInterrupt:
                 if verbose:
                     logger.warning("Waiting interrupted by user")
-            else:
-                if verbose:
-                    logger.info("Waiting interrupted because timeout was reached")
 
     def wait_for_submission(self, timeout: Optional[float] = None, verbose: bool = True) -> None:
         """

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -96,6 +96,7 @@ from neptune_scale.util.shared_var import (
     SharedFloat,
     SharedInt,
 )
+from neptune_scale.util.timer import Timer
 
 logger = get_logger()
 
@@ -345,11 +346,13 @@ class Run(AbstractContextManager):
                 if self._errors_queue is not None:
                     self._errors_queue.put(NeptuneSynchronizationStopped())
 
-    def _close(self, *, wait: bool = True) -> None:
+    def _close(self, *, timeout: Optional[float] = None) -> None:
+        timer = Timer(timeout)
+
         # Console log capture is actually a produced of logged data, so let's flush it before closing.
         # This allows to log tracebacks of the potential exception that caused the run to fail.
         if self._console_log_capture is not None:
-            self._console_log_capture.interrupt(remaining_iterations=1 if wait else 0)
+            self._console_log_capture.interrupt(remaining_iterations=0 if timer.is_expired() else 1)
             self._console_log_capture.join()
 
         with self._lock:
@@ -358,30 +361,29 @@ class Run(AbstractContextManager):
 
             self._is_closing = True
 
-            logger.debug(f"Run is closing, wait={wait}")
+            logger.debug(f"Run is closing, timeout={timeout}")
 
         if self._sync_process is not None and self._sync_process.is_alive():
-            if wait:
-                self.wait_for_processing()
+            self.wait_for_processing(timeout=timer.remaining_time())
 
             self._sync_process.terminate()
-            self._sync_process.join()
+            self._sync_process.join(timeout=timer.remaining_time())
 
         if self._sync_process_supervisor is not None:
             self._sync_process_supervisor.interrupt()
-            self._sync_process_supervisor.join()
+            self._sync_process_supervisor.join(timeout=timer.remaining_time())
 
         if self._lag_tracker is not None:
             self._lag_tracker.interrupt()
-            self._lag_tracker.join()
+            self._lag_tracker.join(timeout=timer.remaining_time())
 
         if self._errors_monitor is not None:
-            self._errors_monitor.interrupt(remaining_iterations=1 if wait else 0)
+            self._errors_monitor.interrupt(remaining_iterations=0 if timer.is_expired() else 1)
 
             # Don't call join() if being called from the error thread, as this will
             # result in a "cannot join current thread" exception.
             if threading.current_thread() != self._errors_monitor:
-                self._errors_monitor.join()
+                self._errors_monitor.join(timeout=timer.remaining_time())
 
         if self._operations_repo is not None:
             self._operations_repo.close(cleanup_files=True)
@@ -420,9 +422,9 @@ class Run(AbstractContextManager):
         if self._exit_func is not None:
             atexit.unregister(self._exit_func)
             self._exit_func = None
-        self._close(wait=False)
+        self._close(timeout=0)
 
-    def close(self) -> None:
+    def close(self, timeout: Optional[float] = None) -> None:
         """
         Closes the connection to Neptune and waits for data synchronization to be completed.
 
@@ -442,7 +444,7 @@ class Run(AbstractContextManager):
         if self._exit_func is not None:
             atexit.unregister(self._exit_func)
             self._exit_func = None
-        self._close(wait=True)
+        self._close(timeout=timeout)
 
     def __exit__(
         self,
@@ -866,14 +868,17 @@ class Run(AbstractContextManager):
         timeout: Optional[float] = None,
         verbose: bool = True,
     ) -> None:
+        if timeout is not None and timeout <= 0:
+            return
+
         if verbose:
             logger.info(f"Waiting for all operations to be {phrase}")
 
         if timeout is None and verbose:
             logger.warning("No timeout specified. Waiting indefinitely")
 
-        begin_time = time.monotonic()
-        wait_time = min(sleep_time, timeout) if timeout is not None else sleep_time
+        timer = Timer(timeout)
+        wait_time = sleep_time
         last_print_timestamp: Optional[float] = None
 
         while True:
@@ -891,9 +896,8 @@ class Run(AbstractContextManager):
                     if wait_seq.value >= self._sequence_tracker.last_sequence_id:
                         break
 
-                if timeout is not None:
-                    time_elapsed = time.monotonic() - begin_time
-                    wait_time = max(0, min(wait_time, timeout - time_elapsed))
+                if timer.is_finite():
+                    wait_time = min(wait_time, timer.remaining_time() or 0)
                 with wait_seq:
                     wait_seq.wait(timeout=wait_time)
                     value = wait_seq.value
@@ -927,9 +931,8 @@ class Run(AbstractContextManager):
                         logger.info(f"All operations were {phrase}")
                     break
 
-                if timeout is not None:
-                    time_elapsed = time.monotonic() - begin_time
-                    if time_elapsed > timeout:
+                if timer.is_finite():
+                    if timer.is_expired():
                         if verbose:
                             logger.info("Waiting interrupted because timeout was reached")
                         break
@@ -949,17 +952,15 @@ class Run(AbstractContextManager):
             timeout (float, optional): In seconds, the maximum time to wait for submission.
             verbose (bool): If True (default), prints messages about the waiting process.
         """
-        begin_time = time.monotonic()
+        timer = Timer(timeout)
         self._wait(
             phrase="submitted",
             sleep_time=MINIMAL_WAIT_FOR_PUT_SLEEP_TIME,
             wait_seq=self._last_queued_seq,
-            timeout=timeout,
+            timeout=timer.remaining_time(),
             verbose=verbose,
         )
-        time_elapsed = time.monotonic() - begin_time
-        remaining_timeout = None if timeout is None else max(0.0, timeout - time_elapsed)
-        self._wait_for_file_upload(timeout=remaining_timeout, verbose=verbose)
+        self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
 
     def wait_for_processing(self, timeout: Optional[float] = None, verbose: bool = True) -> None:
         """
@@ -971,23 +972,24 @@ class Run(AbstractContextManager):
             timeout (float, optional): In seconds, the maximum time to wait for processing.
             verbose (bool): If True (default), prints messages about the waiting process.
         """
-        begin_time = time.monotonic()
+        timer = Timer(timeout)
         self._wait(
             phrase="processed",
             sleep_time=MINIMAL_WAIT_FOR_ACK_SLEEP_TIME,
             wait_seq=self._last_ack_seq,
-            timeout=timeout,
+            timeout=timer.remaining_time(),
             verbose=verbose,
         )
-        time_elapsed = time.monotonic() - begin_time
-        remaining_timeout = None if timeout is None else max(0.0, timeout - time_elapsed)
-        self._wait_for_file_upload(timeout=remaining_timeout, verbose=verbose)
+        self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
 
     def _wait_for_file_upload(
         self,
         timeout: Optional[float] = None,
         verbose: bool = True,
     ) -> None:
+        if timeout is not None and timeout <= 0:
+            return
+
         if verbose:
             logger.info("Waiting for all files to be uploaded")
 
@@ -995,7 +997,7 @@ class Run(AbstractContextManager):
             logger.warning("No timeout specified. Waiting indefinitely")
 
         upload_count_limit = 1_000_000
-        begin_time = time.monotonic()
+        timer = Timer(timeout)
         sleep_time = float(OPERATION_REPOSITORY_POLL_SLEEP_TIME)
         last_print_timestamp: Optional[float] = None
 
@@ -1018,15 +1020,14 @@ class Run(AbstractContextManager):
                         verbose=verbose,
                     )
 
-                    if timeout is not None:
-                        time_elapsed = time.monotonic() - begin_time
-                        if time_elapsed > timeout:
+                    if timer.is_finite():
+                        if timer.is_expired():
                             if verbose:
                                 logger.info("Waiting interrupted because timeout was reached")
                             break
-                        sleep_time = min(sleep_time, timeout - time_elapsed)
-                    if sleep_time > 0:
-                        time.sleep(sleep_time)
+                        sleep_time = min(sleep_time, timer.remaining_time() or 0)
+
+                    time.sleep(sleep_time)
                 else:
                     if verbose:
                         logger.info("All files were uploaded")

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -8,7 +8,6 @@ import base64
 import binascii
 import itertools
 import json
-import math
 import mimetypes
 import re
 import uuid
@@ -897,7 +896,7 @@ class Run(AbstractContextManager):
                     if wait_seq.value >= self._sequence_tracker.last_sequence_id:
                         break
 
-                wait_time = min(wait_time, timer.remaining_time() or math.inf)
+                wait_time = min(wait_time, timer.remaining_time_or_inf())
                 with wait_seq:
                     wait_seq.wait(timeout=wait_time)
                     value = wait_seq.value
@@ -1022,7 +1021,7 @@ class Run(AbstractContextManager):
                         if verbose:
                             logger.info("Waiting interrupted because timeout was reached")
                         break
-                    sleep_time = min(sleep_time, timer.remaining_time() or math.inf)
+                    sleep_time = min(sleep_time, timer.remaining_time_or_inf())
 
                     time.sleep(sleep_time)
                 else:

--- a/src/neptune_scale/cli/commands.py
+++ b/src/neptune_scale/cli/commands.py
@@ -46,13 +46,20 @@ def main() -> None:
     metavar="<api-token>",
     help="API token for authentication. Overrides NEPTUNE_API_TOKEN environment variable",
 )
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Timeout for the sync operation in seconds. Default is None (no timeout).",
+)
 def sync(
     run_log_file: str,
     api_token: Optional[str],
+    timeout: Optional[float],
 ) -> None:
     if api_token is None:
         raise NeptuneApiTokenNotProvided()
 
     run_log_path = Path(run_log_file)
 
-    sync_all(run_log_path, api_token)
+    sync_all(run_log_path, api_token, timeout=timeout)

--- a/src/neptune_scale/cli/sync.py
+++ b/src/neptune_scale/cli/sync.py
@@ -16,7 +16,6 @@
 
 __all__ = ["sync_all"]
 
-import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -154,7 +153,7 @@ class SyncRunner:
                     if timer.is_expired():
                         logger.info("Waiting interrupted because timeout was reached")
                         break
-                    wait_time = min(wait_time, timer.remaining_time() or math.inf)
+                    wait_time = min(wait_time, timer.remaining_time_or_inf())
                     operation_progress = self._wait_operation_submit(
                         last_progress=operation_progress, wait_time=wait_time
                     )
@@ -162,7 +161,7 @@ class SyncRunner:
                     if timer.is_expired():
                         logger.info("Waiting interrupted because timeout was reached")
                         break
-                    wait_time = min(wait_time, timer.remaining_time() or math.inf)
+                    wait_time = min(wait_time, timer.remaining_time_or_inf())
                     file_progress = self._wait_file_upload(last_progress=file_progress, wait_time=wait_time)
 
                     progress_bar.update(operation_progress.progress + file_progress.progress - progress_bar.n)

--- a/src/neptune_scale/util/timer.py
+++ b/src/neptune_scale/util/timer.py
@@ -1,0 +1,24 @@
+import time
+from typing import Optional
+
+
+class Timer:
+    def __init__(self, timeout: Optional[float]) -> None:
+        self.timeout = timeout
+        self.start_time = time.monotonic()
+
+    def remaining_time(self) -> Optional[float]:
+        if self.timeout is None:
+            return None
+
+        elapsed_time = time.monotonic() - self.start_time
+        return max(0.0, self.timeout - elapsed_time)
+
+    def is_expired(self) -> bool:
+        remaining_time = self.remaining_time()
+        if remaining_time is None:
+            return False
+        return remaining_time <= 0.0
+
+    def is_finite(self) -> bool:
+        return self.timeout is not None

--- a/src/neptune_scale/util/timer.py
+++ b/src/neptune_scale/util/timer.py
@@ -1,3 +1,4 @@
+import math
 import time
 from typing import Optional
 
@@ -13,6 +14,12 @@ class Timer:
 
         elapsed_time = time.monotonic() - self.start_time
         return max(0.0, self.timeout - elapsed_time)
+
+    def remaining_time_or_inf(self) -> float:
+        remaining_time = self.remaining_time()
+        if remaining_time is None:
+            return math.inf
+        return remaining_time
 
     def is_expired(self) -> bool:
         if self.timeout is None:

--- a/src/neptune_scale/util/timer.py
+++ b/src/neptune_scale/util/timer.py
@@ -15,10 +15,11 @@ class Timer:
         return max(0.0, self.timeout - elapsed_time)
 
     def is_expired(self) -> bool:
-        remaining_time = self.remaining_time()
-        if remaining_time is None:
+        if self.timeout is None:
             return False
-        return remaining_time <= 0.0
+
+        elapsed_time = time.monotonic() - self.start_time
+        return elapsed_time >= self.timeout
 
     def is_finite(self) -> bool:
         return self.timeout is not None

--- a/tests/e2e/test_run.py
+++ b/tests/e2e/test_run.py
@@ -1,0 +1,33 @@
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from neptune_scale.api.run import Run
+
+NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
+
+
+@pytest.mark.parametrize("timeout", [0, 1, 5])
+@pytest.mark.parametrize(
+    "skipped_method",
+    [
+        "neptune_scale.sync.sync_process.SyncProcess.terminate",
+        "neptune_scale.sync.supervisor.ProcessSupervisor.interrupt",
+        "neptune_scale.sync.errors_tracking.ErrorsMonitor.interrupt",
+    ],
+)
+@pytest.mark.timeout(30)
+def test_close_timeout(run_init_kwargs, timeout, skipped_method):
+    # given
+    run = Run(**run_init_kwargs)
+
+    # when
+    with patch(skipped_method):
+        start_time = time.monotonic()
+        run.close(timeout=timeout)
+        elapsed_time = time.monotonic() - start_time
+
+    # then
+    assert timeout < elapsed_time < timeout + 1

--- a/tests/e2e/test_sync.py
+++ b/tests/e2e/test_sync.py
@@ -4,6 +4,7 @@ from datetime import (
     datetime,
     timezone,
 )
+from unittest.mock import patch
 
 import pytest
 from neptune_fetcher.alpha import (
@@ -13,7 +14,9 @@ from neptune_fetcher.alpha import (
 
 from neptune_scale.api.run import Run
 from neptune_scale.cli import sync
+from neptune_scale.cli.sync import SyncRunner
 from neptune_scale.exceptions import NeptuneUnableToLogData
+from neptune_scale.util import SharedInt
 
 from .conftest import (
     random_series,
@@ -22,7 +25,6 @@ from .conftest import (
 
 NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
 API_TOKEN = os.getenv("NEPTUNE_API_TOKEN")
-SYNC_TIMEOUT = 30
 
 
 def test_sync_empty_file(run_init_kwargs):
@@ -141,3 +143,59 @@ def test_sync_all_types_combined(run_init_kwargs, temp_dir):
 
     # then
     assert not db_path.exists()
+
+
+@pytest.mark.parametrize("timeout", [0, 1, 5])
+@pytest.mark.timeout(30)
+def test_sync_wait_timeout(run_init_kwargs, ro_run, timeout):
+    # given
+    with Run(**run_init_kwargs, mode="offline") as run:
+        db_path = run._operations_repo._db_path
+        data = {"str-value": "hello-world"}
+        run.log_configs(data)
+    runner = SyncRunner(api_token=API_TOKEN, run_log_file=db_path)
+    runner.start()
+    runner._last_ack_seq = SharedInt(1)  # replace so that wait never sees the true progress and hangs
+
+    # when
+    start_time = time.monotonic()
+    runner.wait(timeout=timeout)
+    elapsed_time = time.monotonic() - start_time
+
+    # then
+    assert timeout <= elapsed_time < timeout + 1
+
+
+@pytest.mark.parametrize(
+    "timeout",
+    [
+        0,
+        1,
+        5,
+    ],
+)
+@pytest.mark.parametrize(
+    "hung_method",
+    [
+        "neptune_scale.sync.sync_process.SyncProcess.terminate",
+        "neptune_scale.sync.errors_tracking.ErrorsMonitor.interrupt",
+    ],
+)
+@pytest.mark.timeout(30)
+def test_sync_stop_timeout(run_init_kwargs, ro_run, timeout, hung_method):
+    # given
+    with Run(**run_init_kwargs, mode="offline") as run:
+        db_path = run._operations_repo._db_path
+        data = {"str-value": "hello-world"}
+        run.log_configs(data)
+    runner = SyncRunner(api_token=API_TOKEN, run_log_file=db_path)
+    runner.start()
+
+    # when
+    with patch(hung_method):
+        start_time = time.monotonic()
+        runner.stop(timeout=timeout)
+        elapsed_time = time.monotonic() - start_time
+
+    # then
+    assert timeout <= elapsed_time < timeout + 1

--- a/tests/unit/test_run_resume.py
+++ b/tests/unit/test_run_resume.py
@@ -4,7 +4,7 @@ from neptune_scale import Run
 from neptune_scale.util.generate_run_id import generate_run_id
 
 
-def test_resume_false_with_matching_fork_point(api_token, caplog):
+def test_resume_false_with_matching_fork_point(api_token):
     project = "workspace/project"
     run_id = generate_run_id()
     fork_run_id = "parent-run"

--- a/tests/unit/test_timer.py
+++ b/tests/unit/test_timer.py
@@ -1,0 +1,61 @@
+import time
+
+import pytest
+
+from neptune_scale.util.timer import Timer
+
+
+@pytest.mark.parametrize(
+    "timeout, sleep, remaining_time",
+    (
+        (None, 0, None),
+        (None, 1, None),
+        (1, 0, 1),
+        (1, 0.5, 0.5),
+        (1, 1, 0),
+        (1, 2, 0),
+    ),
+)
+def test_timer_remaining_time(timeout, sleep, remaining_time):
+    timer = Timer(timeout)
+
+    time.sleep(sleep)
+
+    if remaining_time is None:
+        assert timer.remaining_time() is None
+    else:
+        assert timer.remaining_time() <= remaining_time
+
+
+@pytest.mark.parametrize(
+    "timeout, sleep, is_expired",
+    (
+        (None, 0, False),
+        (None, 1, False),
+        (2, 0, False),
+        (2, 0.5, False),
+        (1, 1, True),
+        (1, 2, True),
+    ),
+)
+def test_timer_is_expired(timeout, sleep, is_expired):
+    timer = Timer(timeout)
+
+    time.sleep(sleep)
+
+    assert timer.is_expired() == is_expired
+
+
+@pytest.mark.parametrize(
+    "timeout, is_finite",
+    (
+        (None, False),
+        (0, True),
+        (1, True),
+        (2, True),
+    ),
+)
+def test_timer_is_finite(timeout, is_finite):
+    timer = Timer(timeout)
+
+    assert timer.is_finite() == is_finite

--- a/tests/unit/test_timer.py
+++ b/tests/unit/test_timer.py
@@ -1,3 +1,4 @@
+import math
 import time
 
 import pytest
@@ -25,6 +26,28 @@ def test_timer_remaining_time(timeout, sleep, remaining_time):
         assert timer.remaining_time() is None
     else:
         assert timer.remaining_time() <= remaining_time
+
+
+@pytest.mark.parametrize(
+    "timeout, sleep, remaining_time",
+    (
+        (None, 0, None),
+        (None, 1, None),
+        (1, 0, 1),
+        (1, 0.5, 0.5),
+        (1, 1, 0),
+        (1, 2, 0),
+    ),
+)
+def test_timer_remaining_time_or_inf(timeout, sleep, remaining_time):
+    timer = Timer(timeout)
+
+    time.sleep(sleep)
+
+    if remaining_time is None:
+        assert timer.remaining_time_or_inf() == math.inf
+    else:
+        assert timer.remaining_time_or_inf() <= remaining_time
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Add timeout functionality to close and sync operations to provide more control over resource cleanup and synchronization processes

New Features:
- Introduce a configurable timeout parameter for close and sync operations in Neptune Scale API
- Add a new Timer utility class to manage timeout tracking

Enhancements:
- Modify existing methods to support optional timeout parameters
- Improve resource cleanup and synchronization process with timeout handling

Tests:
- Add unit tests for the new Timer utility class
- Add end-to-end tests for timeout functionality in run close and sync operations

Chores:
- Update CLI commands to support timeout option for sync operation