### PR TITLE
Initialize logger in `console_log_capture.py`

### DIFF
--- a/src/neptune_scale/sync/console_log_capture.py
+++ b/src/neptune_scale/sync/console_log_capture.py
@@ -15,9 +15,16 @@ from typing import (
 
 from neptune_scale.exceptions import NeptuneUnableToLogData
 from neptune_scale.sync.parameters import MAX_STRING_SERIES_DATA_POINT_LENGTH
-from neptune_scale.util import Daemon
+from neptune_scale.util import (
+    Daemon,
+    get_logger,
+)
 
 STREAM_BUFFER_CHAR_CAPACITY = 100_000_000
+
+# Ensure that the Neptune logger is initialized before sys.stderr is switched to.
+# This is important, so that Neptune logs are emitted to the original stderr.
+_logger = get_logger()
 
 
 class StreamWithMemory:


### PR DESCRIPTION
Having this explicitly before we switch out sys.stderr/out makes sure our own logs aren't captured

