### PR TITLE
feat: add system_namespace param to Run

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,4 @@ pytest
 pytest-timeout
 pytest-xdist
 freezegun
-neptune-fetcher @ git+https://github.com/neptune-ai/neptune-fetcher.git@ms/files
+neptune-fetcher @ git+https://github.com/neptune-ai/neptune-fetcher.git@main

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -126,7 +126,7 @@ class Run(AbstractContextManager):
         on_error_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         on_warning_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         enable_console_log_capture: bool = True,
-        monitoring_namespace: Optional[str] = None,
+        system_namespace: Optional[str] = None,
     ) -> None:
         """
         Initializes a run that logs the model-building metadata to Neptune.
@@ -157,7 +157,7 @@ class Run(AbstractContextManager):
                 wasn't caught by other callbacks.
             on_warning_callback: Callback function triggered when a warning occurs.
             enable_console_log_capture: Whether to capture stdout/stderr and log them to Neptune.
-            monitoring_namespace: Attribute path prefix for the captured logs. If not provided, defaults to "monitoring".
+            system_namespace: Attribute path prefix for the captured logs. If not provided, defaults to "system".
         """
 
         if run_id is None:
@@ -179,7 +179,7 @@ class Run(AbstractContextManager):
         verify_type("on_error_callback", on_error_callback, (Callable, type(None)))
         verify_type("on_warning_callback", on_warning_callback, (Callable, type(None)))
         verify_type("enable_console_log_capture", enable_console_log_capture, bool)
-        verify_type("monitoring_namespace", monitoring_namespace, (str, type(None)))
+        verify_type("system_namespace", system_namespace, (str, type(None)))
 
         if resume and creation_time is not None:
             logger.warning("`creation_time` is ignored when used together with `resume`.")
@@ -251,7 +251,7 @@ class Run(AbstractContextManager):
                 if not enable_console_log_capture
                 else ConsoleLogCaptureThread(
                     run_id=run_id,
-                    monitoring_namespace=monitoring_namespace.rstrip("/") if monitoring_namespace else "monitoring",
+                    system_namespace=system_namespace.rstrip("/") if system_namespace else "system",
                     logs_flush_frequency_sec=1,
                     logs_sink=lambda data, step, timestamp: self._log(
                         timestamp=timestamp, string_series=StringSeries(data, step)

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -126,6 +126,7 @@ class Run(AbstractContextManager):
         on_error_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         on_warning_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         enable_console_log_capture: bool = True,
+        monitoring_namespace: Optional[str] = None,
     ) -> None:
         """
         Initializes a run that logs the model-building metadata to Neptune.
@@ -155,6 +156,8 @@ class Run(AbstractContextManager):
             on_error_callback: The default callback function triggered when error occurs. It applies if an error
                 wasn't caught by other callbacks.
             on_warning_callback: Callback function triggered when a warning occurs.
+            enable_console_log_capture: Whether to capture stdout/stderr and log them to Neptune.
+            monitoring_namespace: Attribute path prefix for the captured logs. If not provided, defaults to "monitoring".
         """
 
         if run_id is None:
@@ -175,6 +178,8 @@ class Run(AbstractContextManager):
         verify_type("on_network_error_callback", on_network_error_callback, (Callable, type(None)))
         verify_type("on_error_callback", on_error_callback, (Callable, type(None)))
         verify_type("on_warning_callback", on_warning_callback, (Callable, type(None)))
+        verify_type("enable_console_log_capture", enable_console_log_capture, bool)
+        verify_type("monitoring_namespace", monitoring_namespace, (str, type(None)))
 
         if resume and creation_time is not None:
             logger.warning("`creation_time` is ignored when used together with `resume`.")
@@ -246,6 +251,7 @@ class Run(AbstractContextManager):
                 if not enable_console_log_capture
                 else ConsoleLogCaptureThread(
                     run_id=run_id,
+                    monitoring_namespace=monitoring_namespace.rstrip("/") if monitoring_namespace else "monitoring",
                     logs_flush_frequency_sec=1,
                     logs_sink=lambda data, step, timestamp: self._log(
                         timestamp=timestamp, string_series=StringSeries(data, step)

--- a/src/neptune_scale/logging/console_log_capture.py
+++ b/src/neptune_scale/logging/console_log_capture.py
@@ -144,12 +144,10 @@ class MutableInt:
 
 
 class ConsoleLogCaptureThread(Daemon):
-    STDOUT_ATTRIBUTE = "monitoring/stdout"
-    STDERR_ATTRIBUTE = "monitoring/stderr"
-
     def __init__(
         self,
         run_id: str,
+        monitoring_namespace: str,
         logs_flush_frequency_sec: float,
         logs_sink: Callable[[dict[str, str], Union[float, int], Optional[datetime]], None],
     ) -> None:
@@ -161,9 +159,11 @@ class ConsoleLogCaptureThread(Daemon):
         _subscribe(run_id)
 
         self._stdout_partial_line = PartialLine()
+        self._stdout_attribute = f"{monitoring_namespace}/stdout"
         self._stdout_step = MutableInt(1)
 
         self._stderr_partial_line = PartialLine()
+        self._stderr_attribute = f"{monitoring_namespace}/stderr"
         self._stderr_step = MutableInt(1)
 
     def work(self) -> None:
@@ -179,7 +179,7 @@ class ConsoleLogCaptureThread(Daemon):
             assert _stderr_with_memory is not None
 
             self._process_captured_data_single_stream(
-                self.STDOUT_ATTRIBUTE,
+                self._stdout_attribute,
                 self._stdout_partial_line,
                 self._stdout_step,
                 _stdout_with_memory.get_buffered_data(self._run_id),
@@ -187,7 +187,7 @@ class ConsoleLogCaptureThread(Daemon):
             )
 
             self._process_captured_data_single_stream(
-                self.STDERR_ATTRIBUTE,
+                self._stderr_attribute,
                 self._stderr_partial_line,
                 self._stderr_step,
                 _stderr_with_memory.get_buffered_data(self._run_id),

--- a/src/neptune_scale/logging/console_log_capture.py
+++ b/src/neptune_scale/logging/console_log_capture.py
@@ -147,7 +147,7 @@ class ConsoleLogCaptureThread(Daemon):
     def __init__(
         self,
         run_id: str,
-        monitoring_namespace: str,
+        system_namespace: str,
         logs_flush_frequency_sec: float,
         logs_sink: Callable[[dict[str, str], Union[float, int], Optional[datetime]], None],
     ) -> None:
@@ -159,11 +159,11 @@ class ConsoleLogCaptureThread(Daemon):
         _subscribe(run_id)
 
         self._stdout_partial_line = PartialLine()
-        self._stdout_attribute = f"{monitoring_namespace}/stdout"
+        self._stdout_attribute = f"{system_namespace}/stdout"
         self._stdout_step = MutableInt(1)
 
         self._stderr_partial_line = PartialLine()
-        self._stderr_attribute = f"{monitoring_namespace}/stderr"
+        self._stderr_attribute = f"{system_namespace}/stderr"
         self._stderr_step = MutableInt(1)
 
     def work(self) -> None:

--- a/src/neptune_scale/logging/logging_handler.py
+++ b/src/neptune_scale/logging/logging_handler.py
@@ -44,7 +44,7 @@ class NeptuneLoggingHandler(logging.Handler):
         verify_type("run", run, Run)
         verify_type("level", level, int)
         verify_type("attribute_path", attribute_path, (str, type(None)))
-        path = attribute_path if attribute_path else "monitoring/logs"
+        path = attribute_path if attribute_path else "system/logs"
         verify_max_length("attribute_path", path, MAX_ATTRIBUTE_PATH_LENGTH)
 
         super().__init__(level=level)

--- a/tests/unit/logging/test_console_log_capture.py
+++ b/tests/unit/logging/test_console_log_capture.py
@@ -133,7 +133,7 @@ def test_console_log_capture_thread_captures_stdout(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", system_namespace="system", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -144,15 +144,15 @@ def test_console_log_capture_thread_captures_stdout(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"monitoring/stdout": "Hello"}, 1, ANY)
-    logs_sink.assert_any_call({"monitoring/stdout": "World"}, 2, ANY)
+    logs_sink.assert_any_call({"system/stdout": "Hello"}, 1, ANY)
+    logs_sink.assert_any_call({"system/stdout": "World"}, 2, ANY)
 
 
 def test_console_log_capture_thread_captures_stderr(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", system_namespace="system", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -163,15 +163,15 @@ def test_console_log_capture_thread_captures_stderr(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"monitoring/stderr": "Hello"}, 1, ANY)
-    logs_sink.assert_any_call({"monitoring/stderr": "World"}, 2, ANY)
+    logs_sink.assert_any_call({"system/stderr": "Hello"}, 1, ANY)
+    logs_sink.assert_any_call({"system/stderr": "World"}, 2, ANY)
 
 
 def test_console_log_capture_thread_captures_both_stdout_and_stderr(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", system_namespace="system", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -184,10 +184,10 @@ def test_console_log_capture_thread_captures_both_stdout_and_stderr(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"monitoring/stdout": "Hello stdout"}, 1, ANY)
-    logs_sink.assert_any_call({"monitoring/stderr": "Hello stderr"}, 1, ANY)
-    logs_sink.assert_any_call({"monitoring/stdout": "World stdout"}, 2, ANY)
-    logs_sink.assert_any_call({"monitoring/stderr": "World stderr"}, 2, ANY)
+    logs_sink.assert_any_call({"system/stdout": "Hello stdout"}, 1, ANY)
+    logs_sink.assert_any_call({"system/stderr": "Hello stderr"}, 1, ANY)
+    logs_sink.assert_any_call({"system/stdout": "World stdout"}, 2, ANY)
+    logs_sink.assert_any_call({"system/stderr": "World stderr"}, 2, ANY)
 
 
 LINE_LIMIT = 1024 * 1024
@@ -220,7 +220,7 @@ def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=10, logs_sink=logs_sink
+        run_id="run_id", system_namespace="system", logs_flush_frequency_sec=10, logs_sink=logs_sink
     )
 
     # when
@@ -233,7 +233,7 @@ def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
     # then
     if expected:
         for idx, line in enumerate(expected):
-            logs_sink.assert_any_call({"monitoring/stdout": line}, idx + 1, ANY)
+            logs_sink.assert_any_call({"system/stdout": line}, idx + 1, ANY)
     else:
         logs_sink.assert_not_called()
 
@@ -250,7 +250,7 @@ def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=2, logs_sink=logs_sink
+        run_id="run_id", system_namespace="system", logs_flush_frequency_sec=2, logs_sink=logs_sink
     )
 
     # when
@@ -264,14 +264,14 @@ def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
 
     # then
     for idx, line in enumerate(expected):
-        logs_sink.assert_any_call({"monitoring/stdout": line}, idx + 1, ANY)
+        logs_sink.assert_any_call({"system/stdout": line}, idx + 1, ANY)
 
 
-def test_monitoring_namespace(no_capture):
+def test_system_namespace(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", monitoring_namespace="custom/namespace", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", system_namespace="custom/namespace", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when

--- a/tests/unit/logging/test_console_log_capture.py
+++ b/tests/unit/logging/test_console_log_capture.py
@@ -132,7 +132,9 @@ def no_capture(capsys):
 def test_console_log_capture_thread_captures_stdout(no_capture):
     # given
     logs_sink = Mock()
-    thread = ConsoleLogCaptureThread(run_id="run_id", logs_flush_frequency_sec=0.1, logs_sink=logs_sink)
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+    )
 
     # when
     thread.start()
@@ -149,7 +151,9 @@ def test_console_log_capture_thread_captures_stdout(no_capture):
 def test_console_log_capture_thread_captures_stderr(no_capture):
     # given
     logs_sink = Mock()
-    thread = ConsoleLogCaptureThread(run_id="run_id", logs_flush_frequency_sec=0.1, logs_sink=logs_sink)
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+    )
 
     # when
     thread.start()
@@ -166,7 +170,9 @@ def test_console_log_capture_thread_captures_stderr(no_capture):
 def test_console_log_capture_thread_captures_both_stdout_and_stderr(no_capture):
     # given
     logs_sink = Mock()
-    thread = ConsoleLogCaptureThread(run_id="run_id", logs_flush_frequency_sec=0.1, logs_sink=logs_sink)
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+    )
 
     # when
     thread.start()
@@ -213,7 +219,9 @@ LINE_LIMIT = 1024 * 1024
 def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
-    thread = ConsoleLogCaptureThread(run_id="run_id", logs_flush_frequency_sec=10, logs_sink=logs_sink)
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=10, logs_sink=logs_sink
+    )
 
     # when
     thread.start()
@@ -241,7 +249,9 @@ def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
 def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
-    thread = ConsoleLogCaptureThread(run_id="run_id", logs_flush_frequency_sec=2, logs_sink=logs_sink)
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="monitoring", logs_flush_frequency_sec=2, logs_sink=logs_sink
+    )
 
     # when
     thread.start()
@@ -255,3 +265,22 @@ def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
     # then
     for idx, line in enumerate(expected):
         logs_sink.assert_any_call({"monitoring/stdout": line}, idx + 1, ANY)
+
+
+def test_monitoring_namespace(no_capture):
+    # given
+    logs_sink = Mock()
+    thread = ConsoleLogCaptureThread(
+        run_id="run_id", monitoring_namespace="custom/namespace", logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+    )
+
+    # when
+    thread.start()
+    print("Hello")
+    print("World")
+    thread.interrupt(remaining_iterations=1)
+    thread.join()
+
+    # then
+    logs_sink.assert_any_call({"custom/namespace/stdout": "Hello"}, 1, ANY)
+    logs_sink.assert_any_call({"custom/namespace/stdout": "World"}, 2, ANY)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -464,10 +464,27 @@ def test_run_with_ids_problematic_for_filesystems(api_token, project, run_id):
 
 @pytest.mark.parametrize("enable_console_log_capture", [True, False])
 def test_run_disable_console_log_capture(api_token, enable_console_log_capture):
-    with Run(
-        project="a/b", api_token=api_token, mode="offline", enable_console_log_capture=enable_console_log_capture
-    ) as run:
+    with Run(project="a/b", mode="offline", enable_console_log_capture=enable_console_log_capture) as run:
         if enable_console_log_capture:
             assert run._console_log_capture is not None
         else:
             assert run._console_log_capture is None
+
+
+@pytest.mark.parametrize(
+    "monitoring_namespace, expected_path",
+    [
+        (None, "monitoring"),
+        ("custom/namespace", "custom/namespace"),
+        ("custom/namespace/", "custom/namespace"),
+    ],
+)
+def test_run_monitoring_namespace(monitoring_namespace, expected_path):
+    with Run(
+        project="workspace/project",
+        mode="offline",
+        enable_console_log_capture=True,
+        monitoring_namespace=monitoring_namespace,
+    ) as run:
+        assert run._console_log_capture._stdout_attribute == expected_path + "/stdout"
+        assert run._console_log_capture._stderr_attribute == expected_path + "/stderr"

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -486,5 +486,5 @@ def test_run_monitoring_namespace(monitoring_namespace, expected_path):
         enable_console_log_capture=True,
         monitoring_namespace=monitoring_namespace,
     ) as run:
-        assert run._console_log_capture._stdout_attribute == expected_path + "/stdout"
-        assert run._console_log_capture._stderr_attribute == expected_path + "/stderr"
+        assert run._console_log_capture._stdout_attribute == f"{expected_path}/stdout"
+        assert run._console_log_capture._stderr_attribute == f"{expected_path}/stderr"

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -472,19 +472,19 @@ def test_run_disable_console_log_capture(api_token, enable_console_log_capture):
 
 
 @pytest.mark.parametrize(
-    "monitoring_namespace, expected_path",
+    "system_namespace, expected_path",
     [
-        (None, "monitoring"),
+        (None, "system"),
         ("custom/namespace", "custom/namespace"),
         ("custom/namespace/", "custom/namespace"),
     ],
 )
-def test_run_monitoring_namespace(monitoring_namespace, expected_path):
+def test_run_system_namespace(system_namespace, expected_path):
     with Run(
         project="workspace/project",
         mode="offline",
         enable_console_log_capture=True,
-        monitoring_namespace=monitoring_namespace,
+        system_namespace=system_namespace,
     ) as run:
         assert run._console_log_capture._stdout_attribute == f"{expected_path}/stdout"
         assert run._console_log_capture._stderr_attribute == f"{expected_path}/stderr"


### PR DESCRIPTION
## Summary by Sourcery

Add support for a custom system namespace for console log capture in Neptune runs

New Features:
- Introduce a new `system_namespace` parameter to the Run class to allow customization of the log capture attribute path

Enhancements:
- Modify ConsoleLogCaptureThread to support dynamic monitoring namespace
- Add flexibility to log capture by allowing custom namespace prefixes

Tests:
- Add comprehensive test cases for monitoring namespace functionality
- Verify different namespace input scenarios including None, custom namespace, and namespace with trailing slash