### PR TITLE
Validate attribute path length

### DIFF
--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -20,10 +20,7 @@ from neptune_fetcher.alpha import (
 from pytest import mark
 
 from neptune_scale.api.run import Run
-from neptune_scale.exceptions import (
-    NeptuneAttributePathEmpty,
-    NeptuneAttributePathExceedsSizeLimit,
-)
+from neptune_scale.exceptions import NeptuneAttributePathEmpty
 from neptune_scale.types import File
 
 from .conftest import (
@@ -432,7 +429,7 @@ def test_assign_files_duplicate_attribute_path(run, run_init_kwargs, temp_dir, w
                 "Error determining mime type for e2e/resources/does-not-exist: [Errno 2] No such file or directory: 'e2e/resources/does-not-exist'"
             ],
         ),
-        ({"test_files/file_error6" + "a" * 1024: "e2e/resources/file.txt"}, NeptuneAttributePathExceedsSizeLimit, []),
+        ({"test_files/file_error6" + "a" * 1024: "e2e/resources/file.txt"}, None, ["Field paths must be less than"]),
         (
             {"test_files/file_error7": "e2e/resources/invalid_link_file"},
             None,

--- a/tests/unit/test_metadata_splitter.py
+++ b/tests/unit/test_metadata_splitter.py
@@ -444,9 +444,11 @@ def test_skip_non_finite_float_metrics(value, caplog):
 
 
 @pytest.mark.parametrize("action", ("raise", "drop"))
-@pytest.mark.parametrize("invalid_path", (None, object(), 1, 1.0, True, frozenset(), tuple(), datetime.now()))
+@pytest.mark.parametrize(
+    "invalid_path", (None, "A" * 1025, object(), 1, 1.0, True, frozenset(), tuple(), datetime.now())
+)
 @pytest.mark.parametrize("param_name", ("add_tags", "remove_tags", "configs", "metrics", "files"))
-def test_invalid_path_types(caplog, action, invalid_path, param_name):
+def test_invalid_paths(caplog, action, invalid_path, param_name):
     data = {invalid_path: object()}
     kwargs = {name: None for name in ("add_tags", "remove_tags", "configs", "metrics", "files")}
 
@@ -626,7 +628,9 @@ def test_string_series_to_operations():
 
 
 @pytest.mark.parametrize("action", ("raise", "drop"))
-@pytest.mark.parametrize("invalid_path", (None, object(), 1, 1.0, True, frozenset(), tuple(), datetime.now()))
+@pytest.mark.parametrize(
+    "invalid_path", (None, "A" * 1025, object(), 1, 1.0, True, frozenset(), tuple(), datetime.now())
+)
 def test_string_series_invalid_paths(caplog, action, invalid_path):
     data = StringSeries(data={invalid_path: object()}, step=1)
     with patch("neptune_scale.sync.metadata_splitter.INVALID_VALUE_ACTION", action):


### PR DESCRIPTION
## Summary by Sourcery

Add validation for the byte length of attribute paths and string series values.

Enhancements:
- Optimize length validation by skipping UTF-8 encoding for strings guaranteed to be within the limit based on raw string length.
- Adjust internal streaming logic for string series to accommodate length validation changes before size calculation.

Tests:
- Add test cases for overly long attribute paths and string series values.