### PR TITLE
Add docs + a small change in NeptuneLoggingHandler API

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -163,6 +163,8 @@ class Run(AbstractContextManager):
         if run_id is None:
             run_id = generate_run_id()
 
+        self._fork_step = fork_step
+
         verify_type("run_id", run_id, str)
         verify_type("resume", resume, bool)
         verify_type("project", project, (str, type(None)))
@@ -658,14 +660,18 @@ class Run(AbstractContextManager):
 
     def assign_files(self, files: dict[str, Union[str, Path, bytes, File]]) -> None:
         """
-        Assigns single file values to the specified attributes. Any existing values for these attributes will be
-        overwritten.
+        Assigns single file values to the specified attributes and uploads files' contents.
+        Existing values for are overwritten.
 
-        If the value is a simple source type (str, Path, bytes), it's used directly.
-        Mime type and size are determined from the provided source (file or bytes buffer).
+        If a value is a string or Path, it is treated as a file path.
+        If a value is bytes, it is treated as raw file content to save.
+        If a value is a `File` object, its `source` field is used (string and Path are treated as file paths,
+        bytes are treated as raw file content to save).
 
-        If the value is a `File` object, its `source` field is used, along with the optional `destination`,
-        `mime_type`, and `size_bytes` fields. Any fields not provided will be determined from the provided source.
+        The files are uploaded to the Neptune object storage and the attribute are set to point to the uploaded files.
+
+        Mime type and size are determined from the provided source (file or bytes buffer) automatically,
+        but this mechanism can be overridden by providing `mime_type` and `size_bytes` fields in the `File` object.
 
         Args:
             files: dictionary of files to log, where values are one of: str, Path, bytes, or `File` objects

--- a/src/neptune_scale/logging/logging_handler.py
+++ b/src/neptune_scale/logging/logging_handler.py
@@ -21,10 +21,7 @@ from datetime import (
     datetime,
     timedelta,
 )
-from typing import (
-    Optional,
-    Union,
-)
+from typing import Optional
 
 from neptune_scale import Run
 from neptune_scale.api.validation import (
@@ -44,16 +41,22 @@ from neptune_scale.sync.parameters import (
 
 
 class NeptuneLoggingHandler(logging.Handler):
+    """
+    A logging handler that sends log messages to a Neptune run.
+    In its constructor, it takes:
+    - a Neptune run to log to,
+    - a logging level (default is NOTSET),
+    - an optional attribute path under which to store logs (default is "system/logs").
+    """
+
     def __init__(
         self,
         *,
         run: Run,
-        initial_step: Optional[Union[float, int]] = None,
         level: int = logging.NOTSET,
         attribute_path: Optional[str] = None,
     ) -> None:
         verify_type("run", run, Run)
-        verify_type("initial_step", initial_step, (float, int, type(None)))
         verify_type("level", level, int)
         verify_type("attribute_path", attribute_path, (str, type(None)))
         path = attribute_path if attribute_path else "system/logs"
@@ -62,7 +65,7 @@ class NeptuneLoggingHandler(logging.Handler):
         super().__init__(level=level)
         self._path = path
         self._run = run
-        self._step_tracker = StepTracker(initial_step if initial_step is not None else 0)
+        self._step_tracker = StepTracker(run._fork_step if run._fork_step is not None else 0)
         self._thread_local = threading.local()
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/tests/unit/logging/test_neptune_logging_handler.py
+++ b/tests/unit/logging/test_neptune_logging_handler.py
@@ -70,9 +70,14 @@ def test_initial_step(initial_step):
 
     ts = datetime(2025, 4, 23, 0, 0)
 
-    with Run(project="workspace/project", mode="offline") as run:
+    with Run(
+        project="workspace/project",
+        mode="offline",
+        fork_run_id=None if initial_step is None else "a",
+        fork_step=initial_step,
+    ) as run:
         run.log_string_series = Mock()
-        logger.addHandler(NeptuneLoggingHandler(run=run, initial_step=initial_step))
+        logger.addHandler(NeptuneLoggingHandler(run=run))
 
         for i in range(1, 11):
             logger.info(f"{i}")


### PR DESCRIPTION
## Summary by Sourcery

Update the NeptuneLoggingHandler API to use the run's fork step and improve documentation for file assignment.

Enhancements:
- Modify `NeptuneLoggingHandler` to determine the initial logging step based on the associated `Run` object's fork step, removing the `initial_step` parameter.

Documentation:
- Add a class docstring for `NeptuneLoggingHandler`.
- Clarify the behavior of the `assign_files` method in the `Run` class docstring regarding different input types and automatic property detection.

Tests:
- Update tests for `NeptuneLoggingHandler` to reflect the removal of the `initial_step` parameter.