### PR TITLE
Make `GenericFloatValueNanInfUnsupported` unpickable with default args

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -245,7 +245,7 @@ class Run(AbstractContextManager):
 
             existing_metadata = self._operations_repo.get_metadata()
             if existing_metadata is not None:
-                raise NeptuneDatabaseConflict(path=operations_repository_path)
+                raise NeptuneDatabaseConflict(path=operations_repository_path.name)
             self._operations_repo.save_metadata(self._project, self._run_id)
 
             self._sequence_tracker: Optional[SequenceTracker] = SequenceTracker()

--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pathlib
-
 __all__ = (
     "NeptuneScaleError",
     "NeptuneScaleWarning",
@@ -148,7 +146,7 @@ environment variable to `True`.
 For details, see https://docs.neptune.ai/log_configs
 """
 
-    def __init__(self, *, metric: str, step: Optional[float | int], value: Any) -> None:
+    def __init__(self, metric: str = "", step: Optional[float | int] = None, value: Any = None) -> None:
         super().__init__(metric=metric, step=step, value=value)
 
 
@@ -557,5 +555,5 @@ class NeptuneLocalStorageInUnsupportedVersion(NeptuneScaleError):
 class NeptuneDatabaseConflict(NeptuneScaleError):
     message = """NeptuneDatabaseConflict: Database with the same name `{name}` already exists."""
 
-    def __init__(self, path: pathlib.Path) -> None:
-        super().__init__(name=path.name)
+    def __init__(self, path: str = "") -> None:
+        super().__init__(name=path)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,131 @@
+import pickle
+
+import pytest
+
+from neptune_scale.exceptions import (
+    GenericFloatValueNanInfUnsupported,
+    NeptuneApiTokenNotProvided,
+    NeptuneAsyncLagThresholdExceeded,
+    NeptuneAttributePathEmpty,
+    NeptuneAttributePathExceedsSizeLimit,
+    NeptuneAttributePathInvalid,
+    NeptuneAttributePathNonWritable,
+    NeptuneAttributeTypeMismatch,
+    NeptuneAttributeTypeUnsupported,
+    NeptuneBadRequestError,
+    NeptuneConnectionLostError,
+    NeptuneDatabaseConflict,
+    NeptuneFileMetadataExceedsSizeLimit,
+    NeptuneFileUploadError,
+    NeptuneFileUploadTemporaryError,
+    NeptuneFloatValueNanInfUnsupported,
+    NeptuneInternalServerError,
+    NeptuneInvalidCredentialsError,
+    NeptuneLocalStorageInUnsupportedVersion,
+    NeptuneOperationsQueueMaxSizeExceeded,
+    NeptunePreviewStepNotAfterLastCommittedStep,
+    NeptuneProjectAlreadyExists,
+    NeptuneProjectError,
+    NeptuneProjectInvalidName,
+    NeptuneProjectNotFound,
+    NeptuneProjectNotProvided,
+    NeptuneRetryableError,
+    NeptuneRunConflicting,
+    NeptuneRunError,
+    NeptuneRunInvalidCreationParameters,
+    NeptuneRunNotFound,
+    NeptuneScaleError,
+    NeptuneSeriesStepNonIncreasing,
+    NeptuneSeriesStepNotAfterForkPoint,
+    NeptuneSeriesTimestampDecreasing,
+    NeptuneStringSetExceedsSizeLimit,
+    NeptuneStringValueExceedsSizeLimit,
+    NeptuneSynchronizationStopped,
+    NeptuneTooManyRequestsResponseError,
+    NeptuneUnableToAuthenticateError,
+    NeptuneUnableToLogData,
+    NeptuneUnauthorizedError,
+    NeptuneUnexpectedError,
+    NeptuneUnexpectedResponseError,
+)
+
+# These instances will be pickled and unpickled during test_all_exceptions_are_pickable().
+#
+# If there is an exception that inherits from NeptuneScaleError and is not in this list,
+# test_all_exceptions_are_tested() will fail
+EXCEPTIONS = (
+    GenericFloatValueNanInfUnsupported(),
+    NeptuneApiTokenNotProvided(),
+    NeptuneAsyncLagThresholdExceeded(),
+    NeptuneAttributePathEmpty(),
+    NeptuneAttributePathExceedsSizeLimit(),
+    NeptuneAttributePathInvalid(),
+    NeptuneAttributePathNonWritable(),
+    NeptuneAttributeTypeMismatch(),
+    NeptuneAttributeTypeUnsupported(),
+    NeptuneBadRequestError(),
+    NeptuneConnectionLostError(),
+    NeptuneDatabaseConflict("foo"),
+    NeptuneFileMetadataExceedsSizeLimit(),
+    NeptuneFileUploadError(),
+    NeptuneFileUploadTemporaryError(),
+    NeptuneFloatValueNanInfUnsupported(metric="foo", step=1, value=1),
+    NeptuneInternalServerError(),
+    NeptuneInvalidCredentialsError(),
+    NeptuneLocalStorageInUnsupportedVersion(),
+    NeptuneOperationsQueueMaxSizeExceeded(),
+    NeptunePreviewStepNotAfterLastCommittedStep(),
+    NeptuneProjectAlreadyExists(),
+    NeptuneProjectError(),
+    NeptuneProjectInvalidName(),
+    NeptuneProjectNotFound(),
+    NeptuneProjectNotProvided(),
+    NeptuneRetryableError(),
+    NeptuneRunConflicting(),
+    NeptuneRunError(),
+    NeptuneRunInvalidCreationParameters(),
+    NeptuneRunNotFound(),
+    NeptuneSeriesStepNonIncreasing(),
+    NeptuneSeriesStepNotAfterForkPoint(),
+    NeptuneSeriesTimestampDecreasing(),
+    NeptuneStringSetExceedsSizeLimit(),
+    NeptuneStringValueExceedsSizeLimit(),
+    NeptuneSynchronizationStopped(),
+    NeptuneTooManyRequestsResponseError(),
+    NeptuneUnableToAuthenticateError(),
+    NeptuneUnableToLogData(),
+    NeptuneUnauthorizedError(),
+    NeptuneUnexpectedError(reason="test"),
+    NeptuneUnexpectedResponseError(),
+)
+
+
+@pytest.mark.parametrize("instance", EXCEPTIONS, ids=lambda e: type(e).__name__)
+def test_all_exceptions_are_pickable(instance):
+    """Test that all exceptions are pickable."""
+
+    try:
+        pickled_exception = pickle.dumps(instance)
+        unpickled_exception = pickle.loads(pickled_exception)
+        assert isinstance(unpickled_exception, type(instance))
+    except Exception as e:
+        pytest.fail(f"Exception {type(instance)} is not pickable: {e}")
+
+
+def _all_subclasses(cls):
+    """Recursively find all subclasses of a given class."""
+    subclasses = set(cls.__subclasses__())
+
+    for subclass in cls.__subclasses__():
+        subclasses.update(_all_subclasses(subclass))
+
+    return subclasses
+
+
+def test_all_exceptions_are_tested():
+    all_types = _all_subclasses(NeptuneScaleError)
+    tested_types = set(type(e) for e in EXCEPTIONS)
+    missing_types = all_types - tested_types
+
+    if missing_types:
+        pytest.fail("The following exceptions are not tested: " + ", ".join(t.__name__ for t in missing_types))


### PR DESCRIPTION
Long story short: because we pass an argument to `Exception.__init__()` in `NeptuneScaleError`, when unpickling, the same argument is passed to our exceptions. This would crash on `GenericFloatValueNanInfUnsupported` beacuse it did not accept any args.

Because the message is basically static in this class, it's OK to just accept *args and ignore them

## Summary by Sourcery

Bug Fixes:
- Fixed unpickling issue for `GenericFloatValueNanInfUnsupported` exception by adding support for arbitrary arguments