### PR TITLE
`system_namespace` -> `runtime_namespace`

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -127,8 +127,8 @@ class Run(AbstractContextManager):
         on_error_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         on_warning_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         enable_console_log_capture: bool = True,
-        system_namespace: Optional[str] = None,
         runtime_namespace: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Initializes a run that logs the model-building metadata to Neptune.
@@ -159,7 +159,6 @@ class Run(AbstractContextManager):
                 wasn't caught by other callbacks.
             on_warning_callback: Callback function triggered when a warning occurs.
             enable_console_log_capture: Whether to capture stdout/stderr and log them to Neptune.
-            system_namespace: Deprecated.
             runtime_namespace: Attribute path prefix for the captured logs. If not provided, defaults to "runtime".
 
         """
@@ -187,6 +186,7 @@ class Run(AbstractContextManager):
         verify_type("enable_console_log_capture", enable_console_log_capture, bool)
         verify_type("runtime_namespace", runtime_namespace, (str, type(None)))
 
+        system_namespace: Optional[str] = kwargs.get("system_namespace")
         if system_namespace is not None:
             logger.warning(
                 "`system_namespace` is deprecated and will be removed in a future version. "

--- a/src/neptune_scale/logging/console_log_capture.py
+++ b/src/neptune_scale/logging/console_log_capture.py
@@ -166,7 +166,7 @@ class ConsoleLogCaptureThread(Daemon):
         self,
         *,
         run_id: str,
-        system_namespace: str,
+        runtime_namespace: str,
         initial_step: Union[int, float],
         logs_flush_frequency_sec: float,
         logs_sink: Callable[[dict[str, str], Union[float, int], Optional[datetime]], None],
@@ -179,11 +179,11 @@ class ConsoleLogCaptureThread(Daemon):
         _subscribe(run_id)
 
         self._stdout_partial_line = PartialLine()
-        self._stdout_attribute = f"{system_namespace}/stdout"
+        self._stdout_attribute = f"{runtime_namespace}/stdout"
         self._stdout_step = StepTracker(initial_step)
 
         self._stderr_partial_line = PartialLine()
-        self._stderr_attribute = f"{system_namespace}/stderr"
+        self._stderr_attribute = f"{runtime_namespace}/stderr"
         self._stderr_step = StepTracker(initial_step)
 
     def work(self) -> None:

--- a/src/neptune_scale/logging/logging_handler.py
+++ b/src/neptune_scale/logging/logging_handler.py
@@ -73,7 +73,7 @@ class NeptuneLoggingHandler(logging.Handler):
         verify_type("run", run, Run)
         verify_type("level", level, int)
         verify_type("attribute_path", attribute_path, (str, type(None)))
-        path = attribute_path if attribute_path else "system/logs"
+        path = attribute_path if attribute_path else "runtime/logs"
         verify_max_length("attribute_path", path, MAX_ATTRIBUTE_PATH_LENGTH)
 
         super().__init__(level=level)

--- a/tests/unit/logging/test_console_log_capture.py
+++ b/tests/unit/logging/test_console_log_capture.py
@@ -163,7 +163,7 @@ def test_console_log_capture_thread_captures_stdout(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", system_namespace="system", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", runtime_namespace="runtime", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -174,15 +174,15 @@ def test_console_log_capture_thread_captures_stdout(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"system/stdout": "Hello"}, _make_step(1), ANY)
-    logs_sink.assert_any_call({"system/stdout": "World"}, _make_step(2), ANY)
+    logs_sink.assert_any_call({"runtime/stdout": "Hello"}, _make_step(1), ANY)
+    logs_sink.assert_any_call({"runtime/stdout": "World"}, _make_step(2), ANY)
 
 
 def test_console_log_capture_thread_captures_stderr(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", system_namespace="system", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", runtime_namespace="runtime", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -193,15 +193,15 @@ def test_console_log_capture_thread_captures_stderr(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"system/stderr": "Hello"}, _make_step(1), ANY)
-    logs_sink.assert_any_call({"system/stderr": "World"}, _make_step(2), ANY)
+    logs_sink.assert_any_call({"runtime/stderr": "Hello"}, _make_step(1), ANY)
+    logs_sink.assert_any_call({"runtime/stderr": "World"}, _make_step(2), ANY)
 
 
 def test_console_log_capture_thread_captures_both_stdout_and_stderr(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", system_namespace="system", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
+        run_id="run_id", runtime_namespace="runtime", initial_step=0, logs_flush_frequency_sec=0.1, logs_sink=logs_sink
     )
 
     # when
@@ -214,10 +214,10 @@ def test_console_log_capture_thread_captures_both_stdout_and_stderr(no_capture):
     thread.join()
 
     # then
-    logs_sink.assert_any_call({"system/stdout": "Hello stdout"}, _make_step(1), ANY)
-    logs_sink.assert_any_call({"system/stderr": "Hello stderr"}, _make_step(1), ANY)
-    logs_sink.assert_any_call({"system/stdout": "World stdout"}, _make_step(2), ANY)
-    logs_sink.assert_any_call({"system/stderr": "World stderr"}, _make_step(2), ANY)
+    logs_sink.assert_any_call({"runtime/stdout": "Hello stdout"}, _make_step(1), ANY)
+    logs_sink.assert_any_call({"runtime/stderr": "Hello stderr"}, _make_step(1), ANY)
+    logs_sink.assert_any_call({"runtime/stdout": "World stdout"}, _make_step(2), ANY)
+    logs_sink.assert_any_call({"runtime/stderr": "World stderr"}, _make_step(2), ANY)
 
 
 LINE_LIMIT = 1024 * 1024
@@ -255,7 +255,7 @@ def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", initial_step=0, system_namespace="system", logs_flush_frequency_sec=10, logs_sink=logs_sink
+        run_id="run_id", initial_step=0, runtime_namespace="runtime", logs_flush_frequency_sec=10, logs_sink=logs_sink
     )
 
     # when
@@ -268,7 +268,7 @@ def test_console_log_capture_thread_split_lines(no_capture, prints, expected):
     # then
     if expected:
         for idx, line in enumerate(expected):
-            logs_sink.assert_any_call({"system/stdout": line}, _make_step(idx + 1), ANY)
+            logs_sink.assert_any_call({"runtime/stdout": line}, _make_step(idx + 1), ANY)
     else:
         logs_sink.assert_not_called()
 
@@ -285,7 +285,7 @@ def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
-        run_id="run_id", system_namespace="system", initial_step=0, logs_flush_frequency_sec=2, logs_sink=logs_sink
+        run_id="run_id", runtime_namespace="runtime", initial_step=0, logs_flush_frequency_sec=2, logs_sink=logs_sink
     )
 
     # when
@@ -299,7 +299,7 @@ def test_console_log_capture_thread_merge_lines(no_capture, prints, expected):
 
     # then
     for idx, line in enumerate(expected):
-        logs_sink.assert_any_call({"system/stdout": line}, _make_step(idx + 1), ANY)
+        logs_sink.assert_any_call({"runtime/stdout": line}, _make_step(idx + 1), ANY)
 
 
 @pytest.mark.parametrize("initial_step", (0, 1.0, 1.1, 1.12, 1.123, 1.1234, 1.12345, 1.123456))
@@ -309,7 +309,7 @@ def test_console_log_capture_thread_initial_step(no_capture, initial_step):
     thread = ConsoleLogCaptureThread(
         run_id="run_id",
         initial_step=initial_step,
-        system_namespace="system",
+        runtime_namespace="runtime",
         logs_flush_frequency_sec=0.1,
         logs_sink=logs_sink,
     )
@@ -324,15 +324,15 @@ def test_console_log_capture_thread_initial_step(no_capture, initial_step):
 
     # then
     for idx in range(10):
-        logs_sink.assert_any_call({"system/stdout": f"line-{idx}"}, _make_step(idx + 1, initial=initial_step), ANY)
+        logs_sink.assert_any_call({"runtime/stdout": f"line-{idx}"}, _make_step(idx + 1, initial=initial_step), ANY)
 
 
-def test_system_namespace(no_capture):
+def test_runtime_namespace(no_capture):
     # given
     logs_sink = Mock()
     thread = ConsoleLogCaptureThread(
         run_id="run_id",
-        system_namespace="custom/namespace",
+        runtime_namespace="custom/namespace",
         initial_step=0,
         logs_flush_frequency_sec=0.1,
         logs_sink=logs_sink,

--- a/tests/unit/logging/test_neptune_logging_handler.py
+++ b/tests/unit/logging/test_neptune_logging_handler.py
@@ -86,5 +86,5 @@ def test_initial_step(initial_step):
         initial_step = 0
     for i in range(1, 11):
         run.log_string_series.assert_any_call(
-            data={"system/logs": str(i)}, step=round(initial_step + i / 1e6, 6), timestamp=ts
+            data={"runtime/logs": str(i)}, step=round(initial_step + i / 1e6, 6), timestamp=ts
         )

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -472,19 +472,19 @@ def test_run_disable_console_log_capture(api_token, enable_console_log_capture):
 
 
 @pytest.mark.parametrize(
-    "system_namespace, expected_path",
+    "runtime_namespace, expected_path",
     [
-        (None, "system"),
+        (None, "runtime"),
         ("custom/namespace", "custom/namespace"),
         ("custom/namespace/", "custom/namespace"),
     ],
 )
-def test_run_system_namespace(system_namespace, expected_path):
+def test_run_runtime_namespace(runtime_namespace, expected_path):
     with Run(
         project="workspace/project",
         mode="offline",
         enable_console_log_capture=True,
-        system_namespace=system_namespace,
+        runtime_namespace=runtime_namespace,
     ) as run:
         assert run._console_log_capture._stdout_attribute == f"{expected_path}/stdout"
         assert run._console_log_capture._stderr_attribute == f"{expected_path}/stderr"


### PR DESCRIPTION
## Summary by Sourcery

Rename the console log capture and logging handler namespace parameter from `system_namespace` to `runtime_namespace` across the API and logging modules, update default prefixes from `system` to `runtime`, deprecate the old parameter with a warning, and adjust unit tests accordingly.

Enhancements:
- Rename `system_namespace` arguments and internal attributes to `runtime_namespace` in the API and logging modules.
- Change default console log and logging handler attribute prefixes from `system` to `runtime`.
- Deprecate `system_namespace` parameter with a warning and maintain fallback for compatibility.

Tests:
- Update unit tests to reference `runtime_namespace` and validate expected `runtime/` prefixes instead of `system/`.