### PR TITLE
chore: hide log_histograms

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,4 +8,4 @@ pytest-timeout
 pytest-xdist
 freezegun
 numpy
-neptune-api @ git+https://github.com/neptune-ai/neptune-api.git@dev/histograms
+neptune-api @ git+https://github.com/neptune-ai/neptune-api.git@main

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,4 +8,3 @@ pytest-timeout
 pytest-xdist
 freezegun
 numpy
-neptune-api @ git+https://github.com/neptune-ai/neptune-api.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pattern = "default-unprefixed"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-neptune-api = ">=0.14.0,<0.16.0"
+neptune-api = ">=0.16.0,<0.17.0"
 more-itertools = "^10.0.0"
 psutil = "^5.0.0"
 backoff = "^2.0.0"

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -625,11 +625,6 @@ class Run(AbstractContextManager):
         """
         self._log(timestamp=timestamp, step=step, string_series=data)
 
-    def log_histograms(
-        self, histograms: dict[str, Histogram], step: Union[float, int], *, timestamp: Optional[datetime] = None
-    ) -> None:
-        self._log(timestamp=timestamp, histograms=histograms, step=step)
-
     def add_tags(self, tags: Union[list[str], set[str], tuple[str]], group_tags: bool = False) -> None:
         """
         Adds the list of tags to the run.

--- a/src/neptune_scale/sync/operations_repository.py
+++ b/src/neptune_scale/sync/operations_repository.py
@@ -39,7 +39,8 @@ from neptune_scale.util import (
 
 logger = get_logger()
 
-DB_VERSION = "v2"
+DB_VERSION = "v3"
+BACKWARD_COMPATIBLE_DB_VERSIONS = ("v2", "v3")
 
 SequenceId = typing.NewType("SequenceId", int)
 
@@ -357,7 +358,7 @@ class OperationsRepository:
 
                 version, project, run_id = row
 
-                if version != DB_VERSION:
+                if version not in BACKWARD_COMPATIBLE_DB_VERSIONS:
                     raise NeptuneLocalStorageInUnsupportedVersion()
 
                 return Metadata(project=project, run_id=run_id)

--- a/tests/e2e/test_histograms.py
+++ b/tests/e2e/test_histograms.py
@@ -16,6 +16,7 @@ def raise_on_invalid_value():
         yield
 
 
+@pytest.mark.skip(reason="Histograms are not public yet")
 @pytest.mark.parametrize("values", ("counts", "densities"))
 @pytest.mark.parametrize("use_numpy", (True, False), ids=("np.array", "list"))
 def test_histograms(run, client, project_name, values, use_numpy):


### PR DESCRIPTION
## Summary by Sourcery

Hide histogram logging by removing the public log_histograms method and disabling associated tests pending public availability

Tests:
- Mark histogram tests as skipped until the feature becomes public

Chores:
- Remove public log_histograms method from the Run API