### PR TITLE
Bump neptune-api to `0.16.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pattern = "default-unprefixed"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-neptune-api = ">=0.14.0,<0.16.0"
+neptune-api = ">=0.16.0,<0.17.0"
 more-itertools = "^10.0.0"
 psutil = "^5.0.0"
 backoff = "^2.0.0"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Upgrade neptune-api requirement to ">=0.16.0,<0.17.0" in pyproject.toml