### PR TITLE
Error out on empty histogram bin edges

### DIFF
--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -525,9 +525,9 @@ def _stream_histograms(histograms: dict[str, Histogram]) -> Iterator[tuple[str, 
             )
             continue
 
-        if len(value.bin_edges) > _max_histogram_bin_edges:
+        if not bin_edges or len(bin_edges) > _max_histogram_bin_edges:
             _warn_or_raise_on_invalid_value(
-                f"Histogram bin_edges must be of length <= {_max_histogram_bin_edges} "
+                f"Histogram bin edges must not be empty and must have at most {_max_histogram_bin_edges} elements "
                 f"(got {len(value.bin_edges)} bin edges at `{key}`)"
             )
             continue

--- a/tests/unit/test_histograms.py
+++ b/tests/unit/test_histograms.py
@@ -157,15 +157,16 @@ def test_histograms_valid_paths(path):
     "bin_edges, counts, densities, match_message",
     (
         (None, None, None, "Bin edges must be of type"),
-        ([], None, None, "counts and densities must be set"),  # no values field is set
-        ([], [], [], "cannot be set together"),
+        ([1], None, None, "counts and densities must be set"),  # no values field is set
+        ([1], [], [], "cannot be set together"),
         ([1, 2], [1], [1], "cannot be set together"),  # counts and densities are both set
         ([1, 2], [1, 2], None, "counts must be of length equal to bin_edges - 1"),
         ([1, 2], list(range(100)), None, "counts must be of length equal to bin_edges - 1"),
         ([1, 2], None, [1, 2], "densities must be of length equal to bin_edges - 1"),
         ([1, 2], None, list(range(100)), "densities must be of length equal to bin_edges - 1"),
-        (list(range(514)), list(range(513)), None, "bin_edges must be of length"),
-        (list(range(1000)), list(range(999)), None, "bin_edges must be of length"),
+        ([], [1], None, "bin edges must not be empty"),
+        (list(range(514)), list(range(513)), None, "must have at most"),
+        (list(range(1000)), list(range(999)), None, "must have at most"),
         ([1, "s"], [1], None, "must be numeric"),
         ([1, 2, 3], [1, "s"], None, "must be numeric"),
         ([1, 2], [1.0], None, "must be numeric"),  # counts must be strictly ints


### PR DESCRIPTION
## Summary by Sourcery

Enforce non-empty and maximum-length constraints on histogram bin edges in metadata streaming and update unit tests to validate these new conditions with consistent error messages

Enhancements:
- Validate and error on empty histogram bin edges and enforce a maximum number of edges during metadata streaming
- Standardize and refine error message phrasing for histogram bin edges length constraints

Tests:
- Update histogram unit tests to expect errors for empty bin edges and revised message patterns for max-length and numeric validations