### PR TITLE
Expose `Run.log_histograms()`

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -658,6 +658,43 @@ class Run(AbstractContextManager):
         """
         self._log(timestamp=timestamp, step=step, string_series=data)
 
+    def log_histograms(
+        self, histograms: dict[str, Histogram], step: Union[float, int], *, timestamp: Optional[datetime] = None
+    ) -> None:
+        """Logs the specified histograms at a particular step.
+
+        Args:
+            histograms (dict[str, Histogram]):
+                A dictionary with attribute names as keys and histogram objects as values.
+            step (float or int): Index of the series entry.
+                Tip: Using float rather than int values can be useful, for example, when logging substeps in a batch.
+            timestamp (datetime, optional): Time of logging the histograms data.
+                If not provided, the current time is used.
+                If provided, and `timestamp.tzinfo` is not set, the local timezone is used.
+
+        Example:
+            ```
+            from neptune_scale import Run
+            from neptune_scale.types import Histogram
+
+
+            run = Run(...)
+
+            # for step in iteration
+            my_histogram = Histogram(
+                bin_edges=[0, 1, 40, 89, 1000],
+                counts=[5, 82, 44, 1],
+            )
+            run.log_histograms(
+                histograms={
+                    "layers/1/activations": my_histogram
+                },
+                step=1,
+            )
+            ```
+        """
+        self._log(timestamp=timestamp, histograms=histograms, step=step)
+
     def add_tags(self, tags: Union[list[str], set[str], tuple[str]], group_tags: bool = False) -> None:
         """
         Adds the list of tags to the run.

--- a/src/neptune_scale/types.py
+++ b/src/neptune_scale/types.py
@@ -63,8 +63,46 @@ except ImportError:
 
 @dataclass
 class Histogram:
-    """Represents a histogram with explicit bin edges and counts/densities
-    falling into specific bins.
+    """Represents a histogram with explicit bin edges.
+
+    To specify the data distribution across bins, you can use either counts or densities. Note that n bins have n+1
+    bin edges, so the length of the `bin_edges` argument should be one more than the length of the array
+    that specifies the counts or densities.
+
+    Use the histogram as a value in the dictionary passed to `Run.log_histograms()`.
+
+    Args:
+        bin_edges (Union[list[Union[float, int]], "np.ndarray"]): The bin edges of the histogram.
+            Can't be empty. The maximum number of edges is 513.
+        counts (Union[list[int], "np.ndarray"]): Number of data points that fall into each bin, as a 1D array.
+        densities (Union[list[Union[float, int]], "np.ndarray"]): Probability density function values for each bin,
+            as a 1D array.
+
+    Examples:
+
+        ```
+        from neptune_scale.types import Histogram
+
+
+        neptune_histogram = Histogram(bin_edges=[0, 1, 10, 1000], counts=[135, 289, 45])
+        ```
+
+        Using NumPy:
+
+        ```
+        import numpy as np
+
+
+        a = np.arange(5)
+
+        # Using sample count per bin
+        counts, bin_edges = np.histogram(a, density=False)
+        neptune_histogram = Histogram(bin_edges=bin_edges, counts=counts)
+
+        # Using density values
+        densities, bin_edges = np.histogram(a, density=True)
+        neptune_histogram = Histogram(bin_edges=bin_edges, densities=densities)
+        ```
     """
 
     bin_edges: ArrayLike[Union[float, int]]


### PR DESCRIPTION
## Summary by Sourcery

Enable logging histograms in runs by adding `Run.log_histograms` and detailing `Histogram` usage

New Features:
- Add `Run.log_histograms` method for logging histogram objects

Enhancements:
- Expand `Histogram` documentation with counts/densities usage, argument details, and examples