### PR TITLE
Use `python-version` matrix dimension in unit tests

### DIFF
--- a/.github/workflows/unit-in-pull-request.yml
+++ b/.github/workflows/unit-in-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, windows, macos ]
-        python-version: [ "3.9" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     name: 'test (${{ matrix.os }} - py${{ matrix.python-version }})'
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Extend the `python-version` matrix in the unit test workflow to include versions 3.9, 3.10, 3.11, 3.12, and 3.13