### PR TITLE
Remove upper version bound on `psutil` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python = "^3.9"
 
 neptune-api = ">=0.17.0,<0.18.0"
 more-itertools = "^10.0.0"
-psutil = "^5.0.0"
+psutil = ">=5.0.0"
 backoff = "^2.0.0"
 click = ">=7.0"
 tqdm = "^4.21.0"


### PR DESCRIPTION
We're using stable API. There are no breaking changes for us between 5.9.8 (latest 5.*) and 7.0.0.
