### PR TITLE
feat: return bool from the wait functions

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -990,7 +990,7 @@ class Run(AbstractContextManager):
 
         return result
 
-    def wait_for_submission(self, timeout: Optional[float] = None, verbose: bool = True) -> None:
+    def wait_for_submission(self, timeout: Optional[float] = None, verbose: bool = True) -> bool:
         """
         Waits until all metadata is submitted to Neptune for processing.
 
@@ -1002,10 +1002,11 @@ class Run(AbstractContextManager):
             verbose (bool): If True (default), prints messages about the waiting process.
         """
         timer = Timer(timeout)
-        self._wait_for_operation_submission(timeout=timer.remaining_time(), verbose=verbose)
-        self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
+        submission_status = self._wait_for_operation_submission(timeout=timer.remaining_time(), verbose=verbose)
+        files_status = self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
+        return submission_status and files_status
 
-    def wait_for_processing(self, timeout: Optional[float] = None, verbose: bool = True) -> None:
+    def wait_for_processing(self, timeout: Optional[float] = None, verbose: bool = True) -> bool:
         """
         Waits until all metadata is processed by Neptune.
 
@@ -1016,17 +1017,17 @@ class Run(AbstractContextManager):
             verbose (bool): If True (default), prints messages about the waiting process.
         """
         timer = Timer(timeout)
-        self._wait_for_operation_processing(timeout=timer.remaining_time(), verbose=verbose)
-        self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
+        processing_status = self._wait_for_operation_processing(timeout=timer.remaining_time(), verbose=verbose)
+        file_status = self._wait_for_file_upload(timeout=timer.remaining_time(), verbose=verbose)
+        return processing_status and file_status
 
     def _wait_for_operation_submission(
         self,
         timeout: Optional[float] = None,
         verbose: bool = True,
-    ) -> None:
-        if timeout is not None and timeout <= 0:
-            logger.info("Skipping waiting for operation submission because timeout has already passed")
-            return
+    ) -> bool:
+        if self._operations_repo is None:
+            return True
 
         if verbose:
             logger.info("Waiting for all operations to be processed")
@@ -1043,8 +1044,7 @@ class Run(AbstractContextManager):
                 with self._lock:
                     if self._sync_process is None or not self._sync_process.is_alive():
                         logger.warning("Waiting interrupted because sync process is not running")
-                        break
-                    assert self._operations_repo is not None
+                        timer = Timer(0)  # reset timer to avoid waiting indefinitely
 
                 # assumption: submissions are always behind or equal to the logged operations
                 submitted_sequence_id_range = self._operations_repo.get_operation_submission_sequence_id_range()
@@ -1075,25 +1075,24 @@ class Run(AbstractContextManager):
                 if operations_count > 0:
                     if timer.is_expired():
                         logger.info("Waiting interrupted because timeout was reached")
-                        break
+                        return False
                     sleep_time = min(sleep_time, timer.remaining_time_or_inf())
 
                     time.sleep(sleep_time)
                 else:
                     logger.info("All operations were submitted")
-                    break
+                    return True
             except KeyboardInterrupt:
                 logger.warning("Waiting interrupted by user")
-                return
+                return False
 
     def _wait_for_operation_processing(
         self,
         timeout: Optional[float] = None,
         verbose: bool = True,
-    ) -> None:
-        if timeout is not None and timeout <= 0:
-            logger.info("Skipping waiting for operation processing because timeout has already passed")
-            return
+    ) -> bool:
+        if self._operations_repo is None:
+            return True
 
         if verbose:
             logger.info("Waiting for all operations to be processed")
@@ -1111,8 +1110,7 @@ class Run(AbstractContextManager):
                 with self._lock:
                     if self._sync_process is None or not self._sync_process.is_alive():
                         logger.warning("Waiting interrupted because sync process is not running")
-                        break
-                    assert self._operations_repo is not None
+                        timer = Timer(0)  # reset timer to avoid waiting indefinitely
 
                 operations_count = self._operations_repo.get_operation_count(limit=operations_count_limit)
 
@@ -1125,25 +1123,24 @@ class Run(AbstractContextManager):
 
                     if timer.is_expired():
                         logger.info("Waiting interrupted because timeout was reached")
-                        break
+                        return False
                     sleep_time = min(sleep_time, timer.remaining_time_or_inf())
 
                     time.sleep(sleep_time)
                 else:
                     logger.info("All operations were processed")
-                    break
+                    return True
             except KeyboardInterrupt:
                 logger.warning("Waiting interrupted by user")
-                return
+                return False
 
     def _wait_for_file_upload(
         self,
         timeout: Optional[float] = None,
         verbose: bool = True,
-    ) -> None:
-        if timeout is not None and timeout <= 0:
-            logger.info("Skipping waiting for file upload because timeout has already passed")
-            return
+    ) -> bool:
+        if self._operations_repo is None:
+            return True
 
         if verbose:
             logger.info("Waiting for all files to be uploaded")
@@ -1161,8 +1158,7 @@ class Run(AbstractContextManager):
                 with self._lock:
                     if self._sync_process is None or not self._sync_process.is_alive():
                         logger.warning("Waiting interrupted because sync process is not running")
-                        return
-                assert self._operations_repo is not None
+                        timer = Timer(0)  # reset timer to avoid waiting indefinitely
 
                 upload_count = self._operations_repo.get_file_upload_requests_count(limit=upload_count_limit)
 
@@ -1175,16 +1171,16 @@ class Run(AbstractContextManager):
 
                     if timer.is_expired():
                         logger.info("Waiting interrupted because timeout was reached")
-                        break
+                        return False
                     sleep_time = min(sleep_time, timer.remaining_time_or_inf())
 
                     time.sleep(sleep_time)
                 else:
                     logger.info("All files were uploaded")
-                    break
+                    return True
             except KeyboardInterrupt:
                 logger.warning("Waiting interrupted by user")
-                return
+                return False
 
     def get_run_url(self) -> str:
         """

--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -40,7 +40,7 @@ def test_atoms(run, client, project_name):
     }
 
     run.log_configs(data)
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_attribute_values(client, project_name, custom_run_id=run._run_id, attributes=data.keys())
     for key, value in data.items():
@@ -57,7 +57,7 @@ def test_atoms(run, client, project_name):
     }
 
     run.log_configs(updated_data)
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_attribute_values(client, project_name, custom_run_id=run._run_id, attributes=data.keys())
     for key, value in updated_data.items():
@@ -72,7 +72,7 @@ def test_metric(run, client, project_name):
     for step, value in zip(steps, values):
         run.log_metrics(data={path: value}, step=step)
 
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_metric_values(client=client, project=project_name, custom_run_id=run._run_id, attributes=[path])
     assert list(fetched[path].keys()) == steps
@@ -84,7 +84,7 @@ def test_multiple_metrics(run, client, project_name):
     data = {f"{path_base}-{i}": i for i in range(20)}
 
     run.log_metrics(data, step=1)
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_metric_values(
         client=client, project=project_name, custom_run_id=run._run_id, attributes=data.keys()
@@ -106,7 +106,7 @@ def test_metric_fetch_and_append(run, client, project_name):
     for step, value in zip(steps, values):
         run.log_metrics(data={path: value}, step=step)
 
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_metric_values(client=client, project=project_name, custom_run_id=run._run_id, attributes=[path])
     assert list(fetched[path].keys()) == steps
@@ -117,7 +117,7 @@ def test_metric_fetch_and_append(run, client, project_name):
     for step, value in zip(steps2, values2):
         run.log_metrics(data={path: value}, step=step)
 
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_metric_values(client=client, project=project_name, custom_run_id=run._run_id, attributes=[path])
     assert list(fetched[path].keys()) == steps + steps2
@@ -129,7 +129,7 @@ def test_single_non_finite_metric(run, client, project_name, value):
     path = unique_path("test_series/non_finite")
 
     run.log_metrics(data={path: value}, step=1)
-    run.wait_for_processing(SYNC_TIMEOUT)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
 
     fetched = fetch_metric_values(client=client, project=project_name, custom_run_id=run._run_id, attributes=[path])
     assert path not in fetched
@@ -142,7 +142,7 @@ def test_async_lag_callback():
         async_lag_threshold=0.000001,
         on_async_lag_callback=lambda: event.set(),
     ) as run:
-        run.wait_for_processing(SYNC_TIMEOUT)
+        assert run.wait_for_processing(SYNC_TIMEOUT)
 
         # First callback should be called after run creation
         event.wait(timeout=60)

--- a/tests/e2e/test_sync.py
+++ b/tests/e2e/test_sync.py
@@ -264,3 +264,5 @@ def test_sync_stop_timeout(run_init_kwargs, timeout, hung_method):
 
     # then
     assert timeout <= elapsed_time < timeout + 1
+
+    runner.stop()

--- a/tests/e2e/test_sync_process_failures.py
+++ b/tests/e2e/test_sync_process_failures.py
@@ -59,15 +59,15 @@ def test_run_wait_methods_after_sync_process_dies(wait_for_submission, wait_for_
 
     run.log_metrics({"metric": 2}, step=1)
     if wait_for_submission:
-        run.wait_for_submission()
+        assert not run.wait_for_submission()
 
     run.log_metrics({"metric": 4}, step=2)
     if wait_for_processing:
-        run.wait_for_processing()
+        assert not run.wait_for_processing()
 
     run.assign_files(files={"a-file": b"content"})
     if wait_for_file_upload:
-        run._wait_for_file_upload()
+        assert not run._wait_for_file_upload()
 
     run.close()
 
@@ -78,7 +78,7 @@ def test_sync_process_dies_after_sync_thread_dies():
 
     # fake token should cause SyncThread to die
 
-    run.wait_for_processing()  # assert that it ends
+    assert not run.wait_for_processing()  # assert that it ends
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
@@ -96,13 +96,13 @@ def test_run_wait_methods_after_sync_process_dies_during_wait(
     run.assign_files(files={"a-file": b"content"})
 
     if wait_for_submission:
-        run.wait_for_submission()
+        assert not run.wait_for_submission()
 
     if wait_for_processing:
-        run.wait_for_processing()
+        assert not run.wait_for_processing()
 
     if wait_for_file_upload:
-        run._wait_for_file_upload()
+        assert not run._wait_for_file_upload()
 
     # only assert the process is dead if we did actually wait
     if wait_for_processing or wait_for_submission or wait_for_file_upload:

--- a/tests/unit/test_timer.py
+++ b/tests/unit/test_timer.py
@@ -15,6 +15,8 @@ from neptune_scale.util.timer import Timer
         (1, 0.5, 0.5),
         (1, 1, 0),
         (1, 2, 0),
+        (0, 0, 0),
+        (-1, 0, 0),
     ),
 )
 def test_timer_remaining_time(timeout, sleep, remaining_time):
@@ -37,6 +39,8 @@ def test_timer_remaining_time(timeout, sleep, remaining_time):
         (1, 0.5, 0.5),
         (1, 1, 0),
         (1, 2, 0),
+        (0, 0, 0),
+        (-1, 0, 0),
     ),
 )
 def test_timer_remaining_time_or_inf(timeout, sleep, remaining_time):
@@ -59,6 +63,8 @@ def test_timer_remaining_time_or_inf(timeout, sleep, remaining_time):
         (2, 0.5, False),
         (1, 1, True),
         (1, 2, True),
+        (0, 0, True),
+        (-1, 0, True),
     ),
 )
 def test_timer_is_expired(timeout, sleep, is_expired):
@@ -73,6 +79,7 @@ def test_timer_is_expired(timeout, sleep, is_expired):
     "timeout, is_finite",
     (
         (None, False),
+        (-1, True),
         (0, True),
         (1, True),
         (2, True),


### PR DESCRIPTION
## Summary by Sourcery

Return boolean status from waiting functions and propagate success flags in internal wait helpers; update tests to assert these return values and cover zero/negative timeouts.

Enhancements:
- Make wait_for_submission and wait_for_processing methods return a bool indicating success or failure.
- Refactor internal _wait_for_* helper methods to return bools and handle early-exit scenarios instead of returning None.

Tests:
- Update e2e tests to assert return values of wait_for_submission, wait_for_processing, and file upload waits.
- Add zero and negative timeout cases to Timer unit tests.
- Add runner.stop() cleanup in the end-to-end sync test.