### PR TITLE
fix: extract released version from the gha env variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,12 @@ jobs:
         run: pip install poetry poetry-dynamic-versioning
 
       - name: Build package
-        run: poetry build
+        run: |
+          # TODO: Remove this workaround once https://github.com/orgs/community/discussions/4924 gets resolved
+          # poetry-dynamic-versioning requires annotated tags to them by creation time
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          echo "VERSION=${VERSION}"
+          POETRY_DYNAMIC_VERSIONING_BYPASS="$VERSION" poetry build
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
fixes PY-134

## Summary by Sourcery

Fix version extraction in the release workflow to ensure the correct version is passed to Poetry dynamic versioning.

Bug Fixes:
- Extract the released version from the GitHub ref and apply it as a bypass for poetry-dynamic-versioning during the build step.

CI:
- Add a step in the release workflow to derive the tag name into a VERSION variable and set POETRY_DYNAMIC_VERSIONING_BYPASS before building the package.