### PR TITLE
fix: disable cert verification for gcp again

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -62,3 +62,23 @@ jobs:
           include_passed: true
           annotate_notice: true
           job_name: "e2e tests"
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+            const payload = {
+              username: "GitHub Actions",
+              text: `E2E tests failed in the repository: <https://github.com/${context.repo.owner}/${context.repo.repo}|${context.repo.owner}/${context.repo.repo}>. Please check the details.`
+            };
+            await fetch(webhookUrl, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify(payload)
+            });
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary by Sourcery

Update the E2E GitHub Actions workflow to watch additional files and re-enable disabling TLS certificate verification for GCP.

CI:
- Include .github workflows, dev_requirements.txt, and pyproject.toml in e2e test path filters
- Set NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE to true for GCP runs to disable certificate verification