### PR TITLE
fix: increase timeout in tests

### DIFF
--- a/tests/e2e/test_files.py
+++ b/tests/e2e/test_files.py
@@ -21,7 +21,7 @@ from .test_fetcher import (
 )
 
 NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
-SYNC_TIMEOUT = 30
+SYNC_TIMEOUT = 60
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -22,7 +22,7 @@ from .test_fetcher import (
 )
 
 NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
-SYNC_TIMEOUT = 30
+SYNC_TIMEOUT = 60
 
 
 def test_atoms(run, client, project_name):


### PR DESCRIPTION
It seems that the gcp dev environment takes longer to process than the main env

## Summary by Sourcery

Increase end-to-end test synchronization timeout to reduce flakiness

Bug Fixes:
- Prevent intermittent E2E test failures by doubling the SYNC_TIMEOUT from 30 to 60 seconds

Tests:
- Update SYNC_TIMEOUT constant in test_files.py and test_log_and_fetch.py to 60 seconds

## Summary by Sourcery

Increase the synchronization timeout in end-to-end tests to reduce flakiness by doubling the wait period.

Tests:
- Update SYNC_TIMEOUT in tests/e2e/test_files.py from 30 to 60 seconds
- Update SYNC_TIMEOUT in tests/e2e/test_log_and_fetch.py from 30 to 60 seconds