### PR TITLE
chore: replace multiprocessing errors queue with repository

### DIFF
--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -4,8 +4,8 @@ __all__ = (
     "NeptuneScaleError",
     "NeptuneScaleWarning",
     "NeptuneUnableToLogData",
-    "NeptuneOperationsQueueMaxSizeExceeded",
     "NeptuneUnauthorizedError",
+    "NeptuneBadRequestError",
     "NeptuneInvalidCredentialsError",
     "NeptuneUnexpectedError",
     "NeptuneConnectionLostError",
@@ -38,7 +38,6 @@ __all__ = (
     "NeptuneStringSetExceedsSizeLimit",
     "NeptuneSynchronizationStopped",
     "NeptuneFileMetadataExceedsSizeLimit",
-    "NeptuneAsyncLagThresholdExceeded",
     "NeptuneProjectNotProvided",
     "NeptuneApiTokenNotProvided",
     "NeptuneTooManyRequestsResponseError",
@@ -119,22 +118,6 @@ NeptuneUnableToLogData: An error occurred, preventing Neptune from logging your 
 
     def __init__(self, reason: str = "", **kwargs: Any) -> None:
         super().__init__(reason=reason, **kwargs)
-
-
-class NeptuneOperationsQueueMaxSizeExceeded(NeptuneUnableToLogData):
-    message = """
-{h1}
-NeptuneOperationsQueueMaxSizeExceeded: The amount of data being logged is higher than processing capacity.
-{end}
-
-The synchronization is paused until the queue size drops below the maximum.
-
-To resolve this issue, consider the following:
-    - Throttle the rate of operations
-    - Cautiously increase the queue size through the `max_queue_size` argument.
-        Note: To ensure that memory usage remains within acceptable limits,
-        closely monitor your system's memory consumption.
-"""
 
 
 class NeptuneFloatValueNanInfUnsupported(NeptuneUnableToLogData):
@@ -501,15 +484,6 @@ class NeptuneFileMetadataExceedsSizeLimit(NeptuneScaleError):
 {h1}
 NeptuneFileMetadataExceedsSizeLimit: File metadata is too long. Maximum length is 4KB.
 {end}
-"""
-
-
-class NeptuneAsyncLagThresholdExceeded(NeptuneScaleError):
-    message = """
-{h1}
-NeptuneAsyncLagThresholdExceeded: Neptune is experiencing a high delay in synchronizing data.
-{end}
-This is a temporary problem. If the problem persists, please contact us at support@neptune.ai
 """
 
 

--- a/src/neptune_scale/sync/errors_tracking.py
+++ b/src/neptune_scale/sync/errors_tracking.py
@@ -1,46 +1,24 @@
 from __future__ import annotations
 
-__all__ = ("ErrorsQueue", "ErrorsMonitor")
+__all__ = ("ErrorsMonitor",)
 
-import multiprocessing
-import queue
 import time
 from collections.abc import Callable
-from multiprocessing.context import BaseContext
 from typing import Optional
 
 from neptune_scale.exceptions import (
-    NeptuneAsyncLagThresholdExceeded,
     NeptuneConnectionLostError,
-    NeptuneOperationsQueueMaxSizeExceeded,
     NeptuneRetryableError,
     NeptuneScaleError,
     NeptuneScaleWarning,
-    NeptuneTooManyRequestsResponseError,
     NeptuneUnexpectedError,
 )
+from neptune_scale.sync.operations_repository import OperationsRepository
 from neptune_scale.sync.parameters import ERRORS_MONITOR_THREAD_SLEEP_TIME
 from neptune_scale.util import get_logger
 from neptune_scale.util.daemon import Daemon
 
 logger = get_logger()
-
-
-class ErrorsQueue:
-    def __init__(self, multiprocessing_context: BaseContext) -> None:
-        self._errors_queue: multiprocessing.Queue[BaseException] = multiprocessing_context.Queue()
-
-    def put(self, error: BaseException) -> None:
-        logger.debug("Put error: %s", type(error))
-        self._errors_queue.put(error)
-
-    def get(self, block: bool = True, timeout: Optional[float] = None) -> BaseException:
-        return self._errors_queue.get(block=block, timeout=timeout)
-
-    def close(self) -> None:
-        self._errors_queue.close()
-        # This is needed to avoid hanging the main process
-        self._errors_queue.cancel_join_thread()
 
 
 def default_error_callback(error: BaseException, last_seen_at: Optional[float]) -> None:
@@ -52,11 +30,6 @@ def default_network_error_callback(error: BaseException, last_seen_at: Optional[
         logger.warning(f"A network error occurred: {error}. Retrying...")
 
 
-def default_max_queue_size_exceeded_callback(error: BaseException, last_raised_at: Optional[float]) -> None:
-    if last_raised_at is None or time.time() - last_raised_at > 5:
-        logger.warning(f"Pending operations queue size exceeded: {error}. Retrying...")
-
-
 def default_warning_callback(error: BaseException, last_seen_at: Optional[float]) -> None:
     logger.warning(error)
 
@@ -64,20 +37,14 @@ def default_warning_callback(error: BaseException, last_seen_at: Optional[float]
 class ErrorsMonitor(Daemon):
     def __init__(
         self,
-        errors_queue: ErrorsQueue,
-        on_queue_full_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
-        on_async_lag_callback: Optional[Callable[[], None]] = None,
+        operations_repository: OperationsRepository,
         on_network_error_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         on_error_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
         on_warning_callback: Optional[Callable[[BaseException, Optional[float]], None]] = None,
     ):
         super().__init__(name="ErrorsMonitor", sleep_time=ERRORS_MONITOR_THREAD_SLEEP_TIME)
 
-        self._errors_queue: ErrorsQueue = errors_queue
-        self._on_queue_full_callback: Callable[[BaseException, Optional[float]], None] = (
-            on_queue_full_callback or default_max_queue_size_exceeded_callback
-        )
-        self._on_async_lag_callback: Callable[[], None] = on_async_lag_callback or (lambda: None)
+        self._operations_repository: OperationsRepository = operations_repository
         self._on_network_error_callback: Callable[[BaseException, Optional[float]], None] = (
             on_network_error_callback or default_network_error_callback
         )
@@ -87,30 +54,27 @@ class ErrorsMonitor(Daemon):
         self._on_warning_callback: Callable[[BaseException, Optional[float]], None] = (
             on_warning_callback or default_warning_callback
         )
+        self._last_raised_timestamps: dict[str, float] = {}
 
-        self._last_raised_timestamps: dict[type[BaseException], float] = {}
+        self._drain_errors()
 
-    def get_next(self) -> Optional[BaseException]:
-        try:
-            return self._errors_queue.get(block=False)
-        except queue.Empty:
-            return None
+    def _drain_errors(self) -> None:
+        errors_count = self._operations_repository.get_errors_count()
+        if errors_count > 0:
+            logger.warning(f"Found {errors_count} unprocessed errors from a previous run. Deleting them now.")
+            self._operations_repository.delete_all_errors()
 
     def work(self) -> None:
-        while (error := self.get_next()) is not None:
-            last_raised_at = self._last_raised_timestamps.get(type(error), None)
-            self._last_raised_timestamps[type(error)] = time.time()
+        while op_errors := self._operations_repository.get_errors(limit=1):
+            op_error = op_errors[0]
+            last_raised_at = self._last_raised_timestamps.get(op_error.error_type, None)
+            self._last_raised_timestamps[op_error.error_type] = time.time()
+            error = op_error.deserialize_error()
 
             try:
-                if isinstance(error, NeptuneOperationsQueueMaxSizeExceeded):
-                    self._on_queue_full_callback(error, last_raised_at)
-                elif isinstance(error, NeptuneConnectionLostError):
+                if isinstance(error, NeptuneConnectionLostError):
                     self._on_network_error_callback(error, last_raised_at)
-                elif isinstance(error, NeptuneAsyncLagThresholdExceeded):
-                    self._on_async_lag_callback()
                 elif isinstance(error, NeptuneScaleWarning):
-                    self._on_warning_callback(error, last_raised_at)
-                elif isinstance(error, NeptuneTooManyRequestsResponseError):
                     self._on_warning_callback(error, last_raised_at)
                 elif isinstance(error, NeptuneRetryableError):
                     self._on_warning_callback(error, last_raised_at)
@@ -121,3 +85,6 @@ class ErrorsMonitor(Daemon):
             except Exception as e:
                 # Don't let user errors kill the process
                 logger.error(f"An exception occurred in user callback function: {e}")
+            finally:
+                if op_error.error_id:
+                    self._operations_repository.delete_errors([op_error.error_id])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,12 @@
 import base64
 import json
+import os
+import tempfile
+from pathlib import Path
 
 import pytest
+
+from neptune_scale.sync.operations_repository import OperationsRepository
 
 
 @pytest.fixture(scope="session")
@@ -9,3 +14,18 @@ def api_token():
     return base64.b64encode(
         json.dumps({"api_address": "http://api-address", "api_url": "http://api-url"}).encode("utf-8")
     ).decode("utf-8")
+
+
+@pytest.fixture
+def temp_db_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = os.path.join(temp_dir, "test_operations.db")
+        yield db_path
+
+
+@pytest.fixture
+def operations_repo(temp_db_path):
+    repo = OperationsRepository(db_path=Path(temp_db_path))
+    repo.init_db()
+    yield repo
+    repo.close(cleanup_files=True)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -5,7 +5,6 @@ import pytest
 from neptune_scale.exceptions import (
     GenericFloatValueNanInfUnsupported,
     NeptuneApiTokenNotProvided,
-    NeptuneAsyncLagThresholdExceeded,
     NeptuneAttributePathEmpty,
     NeptuneAttributePathExceedsSizeLimit,
     NeptuneAttributePathInvalid,
@@ -26,7 +25,6 @@ from neptune_scale.exceptions import (
     NeptuneInternalServerError,
     NeptuneInvalidCredentialsError,
     NeptuneLocalStorageInUnsupportedVersion,
-    NeptuneOperationsQueueMaxSizeExceeded,
     NeptunePreviewStepNotAfterLastCommittedStep,
     NeptuneProjectAlreadyExists,
     NeptuneProjectError,
@@ -60,7 +58,6 @@ from neptune_scale.exceptions import (
 EXCEPTIONS = (
     GenericFloatValueNanInfUnsupported(),
     NeptuneApiTokenNotProvided(),
-    NeptuneAsyncLagThresholdExceeded(),
     NeptuneAttributePathEmpty(),
     NeptuneAttributePathExceedsSizeLimit(),
     NeptuneAttributePathInvalid(),
@@ -77,7 +74,6 @@ EXCEPTIONS = (
     NeptuneInternalServerError(),
     NeptuneInvalidCredentialsError(),
     NeptuneLocalStorageInUnsupportedVersion(),
-    NeptuneOperationsQueueMaxSizeExceeded(),
     NeptunePreviewStepNotAfterLastCommittedStep(),
     NeptuneProjectAlreadyExists(),
     NeptuneProjectError(),


### PR DESCRIPTION
fixes PY-164

## Summary by Sourcery

Replace the in-memory multiprocessing errors queue with a persistent error repository in OperationsRepository and switch all error reporting and monitoring to use the database.

Enhancements:
- Introduce OperationError dataclass and create an operation_errors table in the repository.
- Add repository methods to save, fetch, count, and delete errors with serialization/deserialization support.
- Remove the ErrorsQueue abstraction and switch all sync process threads (SenderThread, StatusTrackingThread, FileUploaderThread) to use OperationsRepository.save_errors.
- Refactor ErrorsMonitor to drain and process stored errors from the repository instead of an in-memory queue.
- Bump the repository schema version to v5 to accommodate the new errors table.

Tests:
- Add unit tests for saving, retrieving, counting, and deleting errors in OperationsRepository.
- Update existing sync process and errors monitor tests to remove ErrorsQueue usage and verify repository-based error handling.

Chores:
- Remove deprecated NeptuneOperationsQueueMaxSizeExceeded and NeptuneAsyncLagThresholdExceeded exceptions.
- Clean up fixture definitions and conftest to provide operations_repo instead of errors_queue.