### PR TITLE
Revert to normal e2e test output locally, use "tap" in GitHub runs

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -44,7 +44,7 @@ jobs:
           NEPTUNE_E2E_PROJECT: ${{ secrets[format('E2E_PROJECT_{0}', matrix.env_target)] }}
           NEPTUNE_E2E_CUSTOM_RUN_ID: ${{ vars.E2E_CUSTOM_RUN_ID }}
           NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE: ${{ matrix.env_target == 'GCP' }}
-        run: pytest --junitxml="test-results/test-e2e-${{ matrix.python-version }}.xml" tests/e2e
+        run: pytest --junitxml="test-results/test-e2e-${{ matrix.python-version }}.xml" --tap-stream tests/e2e
 
       - name: Upload test reports
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ ignore_missing_imports = "True"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "--doctest-modules -n 8 --tap-stream"
+addopts = "--doctest-modules -n 8"
 retries = 3
 retry_delay = 2
 


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
