### PR TITLE
fix: handle `None` return value in console log capture write method

### DIFF
--- a/src/neptune_scale/logging/console_log_capture.py
+++ b/src/neptune_scale/logging/console_log_capture.py
@@ -53,6 +53,11 @@ class StreamWithMemory:
         """
         ts = datetime.now()
         chars_written = self._original_stream.write(data)
+
+        # Handle case where write() returns None (some stream implementations do this)
+        if chars_written is None:
+            chars_written = len(data)
+
         with self._lock:
             space_left_in_buffer = STREAM_BUFFER_CHAR_CAPACITY - self._chars_in_buffer
             if chars_written > space_left_in_buffer:


### PR DESCRIPTION
Fixes [PY-174](https://linear.app/neptuneai/issue/PY-174/bug-console-logging-error-when-using-ray)

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Bug Fixes:
- Default to len(data) when the underlying stream's write() returns None in the console log capture write method