### PR TITLE
Improve warning when on-disk queue not deleted on exit

### DIFF
--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -418,8 +418,8 @@ class Run(AbstractContextManager):
                 logger.debug(f"Failed to remove operations repository directory: {e}")
                 logger.warning(
                     f"The directory containing logged metadata was not deleted. "
-                    f"This may mean that some data wasn't synced successfully. "
-                    f"To manually sync and clean up the directory, run: `neptune sync {self._operations_repository_path}`"
+                    f"This means that some data may have failed to sync. "
+                    f"To finish syncing the data, run: `neptune sync {self._operations_repository_path}`"
                 )
 
     def terminate(self) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Enhance handling and messaging when the on-disk operations queue isn’t deleted on exit by persisting the repository path and improving logging and user guidance.

Enhancements:
- Persist the operations repository path as a class attribute for consistent reuse
- Refine debug logs for directory removal attempts and log failures at debug level
- Add a user-facing warning with instructions to manually sync and clean up the storage directory on removal failure