### PR TITLE
feat: s3 multipart upload

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -41,7 +41,6 @@ jobs:
         env:
           NEPTUNE_E2E_API_TOKEN: ${{ secrets[format('E2E_API_TOKEN_{0}', matrix.env_target)] }}
           NEPTUNE_E2E_PROJECT: ${{ secrets[format('E2E_PROJECT_{0}', matrix.env_target)] }}
-          NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE: ${{ matrix.env_target == 'GCP' }}
         run: pytest --junitxml="test-results/test-e2e-${{ matrix.python-version }}.xml" --tap-stream tests/e2e
 
       - name: Upload test reports

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -21,8 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.13" ]
-        # env_target: [ "AZURE", "GCP", "AWS" ]
-        env_target: [ "AZURE" ]
+        env_target: [ "AZURE", "GCP", "AWS" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -1145,7 +1145,7 @@ class Run(AbstractContextManager):
                     file_path = Path(source)
                     mime_type = mime_type or guess_mime_type_from_file(file_path, destination)
                     if mime_type is None:
-                        raise Exception(f"Cannot determine mime type for file '{file_path}'")
+                        raise ValueError(f"Cannot determine mime type for file '{file_path}'")
                     size = size or file_path.stat().st_size
                 else:
                     logger.warning(f"Skipping file attribute `{attr_name}`: Unsupported type {type(file)}")

--- a/src/neptune_scale/sync/storage/gcs.py
+++ b/src/neptune_scale/sync/storage/gcs.py
@@ -60,7 +60,7 @@ async def _upload_file(client: AsyncClient, session_uri: str, file_path: str, fi
         while file_position < file_size:
             chunk = await file.read(chunk_size)
             if not chunk:
-                raise Exception("File truncated during upload")
+                raise OSError("File truncated during upload")
 
             upload_position = await _upload_chunk(client, session_uri, chunk, file_position, file_size)
             file_position += len(chunk)

--- a/src/neptune_scale/sync/storage/s3.py
+++ b/src/neptune_scale/sync/storage/s3.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 
 import aiofiles
@@ -12,15 +13,14 @@ from neptune_scale.sync.parameters import (
 )
 from neptune_scale.util import get_logger
 
-__all__ = ["upload_to_s3"]
+__all__ = ["upload_to_s3_single", "upload_to_s3_multipart"]
 
 logger = get_logger()
 
 
-async def upload_to_s3(file_path: str, content_type: str, signed_url: str) -> None:
+async def upload_to_s3_single(file_path: str, content_type: str, signed_url: str) -> None:
     """
-    Upload a file to S3 using a signed URL. The upload is done in a single part and resumed in case of a failure.
-    TODO: Implement multipart upload for larger files.
+    Upload a file to S3 using a signed URL. The upload is done in a single part and is retried in case of a failure.
 
     Raises NeptuneFileUploadTemporaryError if a retryable error happens, otherwise any other non-retryable exception
     that occurs.
@@ -30,7 +30,17 @@ async def upload_to_s3(file_path: str, content_type: str, signed_url: str) -> No
 
     try:
         async with AsyncClient(timeout=httpx.Timeout(timeout=HTTP_CLIENT_NETWORKING_TIMEOUT)) as client:
-            await _upload_file(client, signed_url, file_path, content_type)
+            async with aiofiles.open(file_path, "rb") as file:
+                file_size = Path(file_path).stat().st_size
+                if file_size == 0:
+                    await _upload_content(client, signed_url, b"", content_type)
+                    return
+
+                content = await file.read()
+                if not content:
+                    raise Exception("File truncated during upload")
+
+                await _upload_content(client, signed_url, content, content_type)
     except httpx.RequestError as e:
         logger.debug(f"Temporary error while uploading {file_path}: {e}")
         raise NeptuneFileUploadTemporaryError() from e
@@ -44,19 +54,54 @@ async def upload_to_s3(file_path: str, content_type: str, signed_url: str) -> No
     logger.debug(f"Finished upload to S3: {file_path}")
 
 
-async def _upload_file(client: AsyncClient, signed_url: str, file_path: str, content_type: str) -> None:
-    # TODO: Implement multipart upload for larger files
-    file_size = Path(file_path).stat().st_size
-    if file_size == 0:
-        await _upload_part(client, signed_url, b"", content_type)
-        return
+async def upload_to_s3_multipart(
+    file_path: str, content_type: str, part_size: int, part_urls: list[str]
+) -> dict[int, str]:
+    """
+    Upload a file to S3 using a signed URL. The upload uses multiple signed urls for each part and finishes the upload
+    by calling the complete multipart upload endpoint.
 
-    async with aiofiles.open(file_path, "rb") as file:
-        content = await file.read()
-        if not content:
-            raise Exception("File truncated during upload")
+    Raises NeptuneFileUploadTemporaryError if a retryable error happens, otherwise any other non-retryable exception
+    that occurs.
+    """
 
-        await _upload_part(client, signed_url, content, content_type)
+    logger.debug(f"Starting upload to S3: {file_path}, {content_type=}")
+
+    async def upload_part(part_ix: int, part_url: str, content: bytes) -> tuple[int, str]:
+        etag = await _upload_content(client, part_url, content, content_type)
+        return part_ix, etag
+
+    try:
+        async with AsyncClient(timeout=httpx.Timeout(timeout=HTTP_CLIENT_NETWORKING_TIMEOUT)) as client:
+            file_size = Path(file_path).stat().st_size
+            if file_size == 0:
+                raise Exception("Cannot upload an empty file with multipart upload")
+
+            async with aiofiles.open(file_path, "rb") as file:
+                tasks = []
+                for part_ix, part_url in enumerate(part_urls, start=1):
+                    content = await file.read(part_size)
+
+                    if not content:
+                        raise Exception("File truncated during upload")
+
+                    tasks.append(upload_part(part_ix, part_url, content))
+
+                results = await asyncio.gather(*tasks)
+                etags = dict(results)
+
+        logger.debug(f"Finished upload to S3: {file_path}")
+        return etags
+
+    except httpx.RequestError as e:
+        logger.debug(f"Temporary error while uploading {file_path}: {e}")
+        raise NeptuneFileUploadTemporaryError() from e
+    except httpx.HTTPStatusError as e:
+        logger.debug(f"HTTP {e.response.status_code} error while uploading {file_path}: {e}, {e.response.content=!r}")
+        if _is_retryable_httpx_error(e):
+            raise NeptuneFileUploadTemporaryError() from e
+        else:
+            raise
 
 
 def _is_retryable_httpx_error(exc: Exception) -> bool:
@@ -78,10 +123,15 @@ def _is_retryable_httpx_error(exc: Exception) -> bool:
 
 
 @backoff.on_predicate(backoff.expo, _is_retryable_httpx_error, max_time=HTTP_REQUEST_MAX_TIME_SECONDS)
-async def _upload_part(client: AsyncClient, session_uri: str, content: bytes, content_type: str) -> None:
+async def _upload_content(client: AsyncClient, session_uri: str, content: bytes, content_type: str) -> str:
     # The docs at https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html
     # provide Content-Type as the only header
     headers = {"Content-Type": content_type}
 
     response = await client.put(session_uri, headers=headers, content=content)
     response.raise_for_status()
+
+    etag = response.headers.get("ETag", "")
+    if not etag:
+        raise Exception("ETag header missing in S3 upload response")
+    return str(etag).strip('"')

--- a/src/neptune_scale/sync/sync_process.py
+++ b/src/neptune_scale/sync/sync_process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from pathlib import Path
 
 from neptune_api.models import Provider
@@ -17,7 +18,10 @@ from neptune_scale.sync.operations_repository import (
 from neptune_scale.sync.size_util import proto_encoded_bytes_field_size
 from neptune_scale.sync.storage.azure_storage import upload_to_azure
 from neptune_scale.sync.storage.gcs import upload_to_gcp
-from neptune_scale.sync.storage.s3 import upload_to_s3
+from neptune_scale.sync.storage.s3 import (
+    upload_to_s3_multipart,
+    upload_to_s3_single,
+)
 
 __all__ = ("run_sync_process",)
 
@@ -26,6 +30,7 @@ import functools as ft
 import os
 import signal
 import threading
+from collections.abc import Mapping
 from types import FrameType
 from typing import (
     Optional,
@@ -556,7 +561,7 @@ class FileUploaderThread(Daemon):
                     )
                     for file in file_upload_requests
                 ]
-                storage_urls = fetch_file_storage_urls(self._api_client, self._project, file_sign_requests)
+                storage_urls_all = fetch_file_storage_urls(self._api_client, self._project, file_sign_requests)
 
                 # Fan out file uploads as async tasks, and block until all tasks are done.
                 # Note that self._upload_file() should not raise an exception, as they are handled
@@ -564,8 +569,8 @@ class FileUploaderThread(Daemon):
                 # waits for all the tasks to finish regardless of any exceptions.
                 tasks = []
                 for file in file_upload_requests:
-                    provider, storage_url = storage_urls[file.destination]
-                    tasks.append(self._upload_file(file, provider, storage_url))
+                    storage_urls = storage_urls_all[file.destination]
+                    tasks.append(self._upload_file(file, storage_urls))
 
                 self._aio_loop.run_until_complete(asyncio.gather(*tasks, return_exceptions=True))
 
@@ -578,14 +583,32 @@ class FileUploaderThread(Daemon):
             self.interrupt()
             raise NeptuneSynchronizationStopped() from e
 
-    async def _upload_file(self, file: FileUploadRequest, provider: str, storage_url: str) -> None:
+    async def _upload_file(self, file: FileUploadRequest, storage_urls: StorageUrlResult) -> None:
         try:
+            provider = storage_urls.provider
             if provider == Provider.AZURE:
-                await upload_to_azure(file.source_path, file.mime_type, storage_url, chunk_size=self._upload_chunk_size)
+                await upload_to_azure(
+                    file.source_path, file.mime_type, storage_urls.url, chunk_size=self._upload_chunk_size
+                )
             elif provider == Provider.GCP:
-                await upload_to_gcp(file.source_path, file.mime_type, storage_url, chunk_size=self._upload_chunk_size)
+                await upload_to_gcp(
+                    file.source_path, file.mime_type, storage_urls.url, chunk_size=self._upload_chunk_size
+                )
             elif provider == Provider.AWS:
-                await upload_to_s3(file.source_path, file.mime_type, storage_url)
+                if storage_urls.multipart_upload is None:
+                    await upload_to_s3_single(file.source_path, file.mime_type, storage_urls.url)
+                else:
+                    multipart = storage_urls.multipart_upload
+                    etags = await upload_to_s3_multipart(
+                        file.source_path, file.mime_type, multipart.part_size, multipart.part_urls
+                    )
+                    complete_multipart_upload(
+                        self._api_client,
+                        project=self._project,
+                        upload_id=multipart.upload_id,
+                        destination=file.destination,
+                        etags=etags,
+                    )
             else:
                 raise NeptuneUnexpectedError(f"Unsupported file storage provider: {provider}")
 
@@ -610,17 +633,31 @@ class FileUploaderThread(Daemon):
             self._aio_loop.close()
 
 
+@dataclass(frozen=True)
+class MultipartUpload:
+    upload_id: str
+    part_size: int
+    part_urls: list[str]
+
+
+@dataclass(frozen=True)
+class StorageUrlResult:
+    provider: Provider
+    url: str
+    multipart_upload: Optional[MultipartUpload]
+
+
 @backoff.on_exception(backoff.expo, NeptuneRetryableError, max_time=HTTP_REQUEST_MAX_TIME_SECONDS)
 @with_api_errors_handling
 def fetch_file_storage_urls(
     client: ApiClient, project: str, file_sign_requests: list[FileSignRequest]
-) -> dict[str, tuple[str, str]]:
+) -> dict[str, StorageUrlResult]:
     """Fetch signed URLs for storing files. Returns a dict of target_path -> (provider, upload url)."""
 
     logger.debug("Fetching file storage urls")
     response = client.fetch_file_storage_urls(file_sign_requests=file_sign_requests, project=project)
     status_code = response.status_code
-    if status_code != 200:
+    if status_code // 100 != 2:
         logger.debug(f"{response.content=!r}")
         _raise_exception(status_code)
 
@@ -628,13 +665,31 @@ def fetch_file_storage_urls(
     if parsed is None:
         raise NeptuneUnexpectedResponseError("Server response is empty")
 
-    result = {}
+    results = {}
     for file in parsed.files or []:
+        multipart_upload = None
         if file.multipart:
-            # TODO support multipart uploads
-            raise NeptuneUnexpectedResponseError(
-                f"Server returned multipart file upload URLs for the file {file.url}, which are not supported"
+            multipart_upload = MultipartUpload(
+                upload_id=file.multipart.upload_id,
+                part_size=file.multipart.part_size,
+                part_urls=list(file.multipart.part_urls),
             )
 
-        result[file.path] = (file.provider, file.url)
-    return result
+        result = StorageUrlResult(provider=file.provider, url=file.url, multipart_upload=multipart_upload)
+        results[file.path] = result
+    return results
+
+
+@backoff.on_exception(backoff.expo, NeptuneRetryableError, max_time=HTTP_REQUEST_MAX_TIME_SECONDS)
+@with_api_errors_handling
+def complete_multipart_upload(
+    client: ApiClient, project: str, upload_id: str, destination: str, etags: Mapping[int, str]
+) -> None:
+    """Fetch signed URLs for storing files. Returns a dict of target_path -> (provider, upload url)."""
+
+    logger.debug("Completing multipart upload")
+    response = client.complete_multipart_upload(upload_id=upload_id, project=project, path=destination, etags=etags)
+    status_code = response.status_code
+    if status_code // 100 != 2:
+        logger.debug(f"{response.content=!r}")
+        _raise_exception(status_code)

--- a/src/neptune_scale/sync/sync_process.py
+++ b/src/neptune_scale/sync/sync_process.py
@@ -642,7 +642,7 @@ class MultipartUpload:
 
 @dataclass(frozen=True)
 class StorageUrlResult:
-    provider: Provider
+    provider: str
     url: str
     multipart_upload: Optional[MultipartUpload]
 
@@ -675,7 +675,7 @@ def fetch_file_storage_urls(
                 part_urls=list(file.multipart.part_urls),
             )
 
-        result = StorageUrlResult(provider=file.provider, url=file.url, multipart_upload=multipart_upload)
+        result = StorageUrlResult(provider=str(file.provider), url=file.url, multipart_upload=multipart_upload)
         results[file.path] = result
     return results
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -112,7 +112,7 @@ def random_series(length=10, start_step=0):
 def api_token() -> str:
     api_token = os.getenv("NEPTUNE_E2E_API_TOKEN")
     if api_token is None:
-        raise RuntimeError("NEPTUNE_API_TOKEN environment variable is not set")
+        raise RuntimeError("NEPTUNE_E2E_API_TOKEN environment variable is not set")
     return api_token
 
 

--- a/tests/e2e/test_files.py
+++ b/tests/e2e/test_files.py
@@ -54,6 +54,12 @@ SYNC_TIMEOUT = 60
         {"test_files/汉字Пр\U00009999/file_txt2": "e2e/resources/file.txt"},
         {"test_files/file_path_length1-" + "a" * 47: "e2e/resources/file.txt"},  # just below file metadata limit
         {"test_files/file_large1": random.randbytes(10 * 1024 * 1024)},
+        {
+            "test_files/file_large2": File(
+                "\n".join(chr(ord("a") + line) * 1024 * 1023 for line in range(11)).encode("utf8"),
+                mime_type="text/plain",
+            )
+        },
         {"test_files/file_empty1": "e2e/resources/empty_file"},
         {"test_files/file_metadata1": File("e2e/resources/file.txt", mime_type="a" * 128)},
         {"test_files/file_metadata2": File("e2e/resources/file.txt", destination="a" * 800)},


### PR DESCRIPTION
fixes PY-192

## Summary by Sourcery

Implement multipart upload support for AWS S3 in the sync process and refactor storage URL handling to unify single and multipart workflows.

New Features:
- Support AWS S3 multipart upload with automatic part completion in the file uploader thread

Enhancements:
- Refactor fetch_file_storage_urls to return structured StorageUrlResult with multipart info
- Split S3 storage functions into upload_to_s3_single and upload_to_s3_multipart and add complete_multipart_upload API client method

Tests:
- Extend unit tests to cover AWS provider, including multipart upload paths
- Add large file multipart scenario in end-to-end tests

Chores:
- Rename environment variable check for E2E tests to NEPTUNE_E2E_API_TOKEN