### PR TITLE
Limit e2e tests to AZURE envs only

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.13" ]
-        env_target: [ "AZURE", "GCP", "AWS" ]
+        # env_target: [ "AZURE", "GCP", "AWS" ]
+        env_target: [ "AZURE" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Ops are working on stable envs on GCP and AWS, so this is temporary

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
