### PR TITLE
 chore: rename NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE to NEPTUNE_VERIFY_SSL

### DIFF
--- a/src/neptune_scale/net/api_client.py
+++ b/src/neptune_scale/net/api_client.py
@@ -188,7 +188,11 @@ class ApiClient:
     def __init__(self, api_token: str) -> None:
         credentials = Credentials.from_api_key(api_key=api_token)
 
-        verify_ssl: bool = get_bool(VERIFY_SSL, default=not get_bool(ALLOW_SELF_SIGNED_CERTIFICATE, False))
+        verify_ssl: bool = get_bool(
+            VERIFY_SSL,
+            default_invalid=True,
+            default_missing=not get_bool(ALLOW_SELF_SIGNED_CERTIFICATE, default_missing=False, default_invalid=False),
+        )
 
         logger.debug("Trying to connect to Neptune API")
         config, token_urls = get_config_and_token_urls(credentials=credentials, verify_ssl=verify_ssl)

--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -68,7 +68,7 @@ T = TypeVar("T")
 
 
 INVALID_VALUE_ACTION = envs.get_option(envs.LOG_FAILURE_ACTION, ("drop", "raise"), "drop")
-SHOULD_SKIP_NON_FINITE_METRICS = envs.get_bool(envs.SKIP_NON_FINITE_METRICS, True)
+SHOULD_SKIP_NON_FINITE_METRICS = envs.get_bool(envs.SKIP_NON_FINITE_METRICS, default_missing=True, default_invalid=True)
 
 
 @dataclass(frozen=True)

--- a/src/neptune_scale/util/envs.py
+++ b/src/neptune_scale/util/envs.py
@@ -28,11 +28,11 @@ MAX_CONCURRENT_FILE_UPLOADS = "NEPTUNE_MAX_CONCURRENT_FILE_UPLOADS"
 MODE_ENV_NAME = "NEPTUNE_MODE"
 
 
-def get_bool(name: str, default: bool) -> bool:
+def get_bool(name: str, default_missing: bool, default_invalid: bool) -> bool:
     env_val = os.getenv(name)
 
     if env_val is None:
-        return default
+        return default_missing
 
     if env_val.lower() in ("true", "1"):
         return True
@@ -40,7 +40,7 @@ def get_bool(name: str, default: bool) -> bool:
     if env_val.lower() in ("false", "0"):
         return False
 
-    return default
+    return default_invalid
 
 
 def get_positive_int(name: str, default: int) -> int:

--- a/tests/e2e/test_fetcher/client.py
+++ b/tests/e2e/test_fetcher/client.py
@@ -38,7 +38,7 @@ from neptune_scale.util.envs import (
 )
 
 NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS: Final[float] = float(os.environ.get("NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS", "60"))
-NEPTUNE_VERIFY_SSL: Final[bool] = get_bool(VERIFY_SSL, True)
+NEPTUNE_VERIFY_SSL: Final[bool] = get_bool(VERIFY_SSL, default_missing=True, default_invalid=True)
 
 
 @dataclass

--- a/tests/unit/test_envs.py
+++ b/tests/unit/test_envs.py
@@ -50,7 +50,7 @@ def test_get_option_unknown(monkeypatch):
         ("true", "xyz", True),
         ("xyz", None, True),
         ("xyz", "false", True),
-        ("xyz", "true", False),
+        ("xyz", "true", True),
         ("xyz", "xyz", True),
     ),
 )
@@ -64,6 +64,10 @@ def test_ssl_option_fallback(monkeypatch, verify_ssl, allow_self_signed_certific
     else:
         monkeypatch.delenv(ALLOW_SELF_SIGNED_CERTIFICATE, raising=False)
 
-    result = get_bool(VERIFY_SSL, default=not get_bool(ALLOW_SELF_SIGNED_CERTIFICATE, False))
+    result = get_bool(
+        VERIFY_SSL,
+        default_invalid=True,
+        default_missing=not get_bool(ALLOW_SELF_SIGNED_CERTIFICATE, default_missing=False, default_invalid=False),
+    )
 
     assert result == expected


### PR DESCRIPTION
fixes PY-162

## Summary by Sourcery

Use a new VERIFY_SSL environment variable to control SSL verification in the API client and deprecate the old NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE variable with a fallback to maintain backwards compatibility.

Enhancements:
- Introduce the VERIFY_SSL constant and boolean parsing helper for env vars in util/envs
- Switch ApiClient to use get_bool for SSL verification and fallback to the old ALLOW_SELF_SIGNED_CERTIFICATE value if VERIFY_SSL is unset

Chores:
- Rename NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE to VERIFY_SSL in the codebase

## Summary by Sourcery

Replace the old NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE variable with a new VERIFY_SSL env var for SSL verification, update the boolean parsing helper and ApiClient to use the new variable with backward-compatible fallback, and add tests for the fallback logic

Enhancements:
- Introduce VERIFY_SSL environment variable and extend get_bool to handle default and invalid boolean values explicitly
- Update ApiClient to derive SSL verification from VERIFY_SSL with a fallback to the deprecated ALLOW_SELF_SIGNED_CERTIFICATE

Tests:
- Add parameterized tests for SSL verification fallback behavior between VERIFY_SSL and ALLOW_SELF_SIGNED_CERTIFICATE

Chores:
- Rename NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE references to VERIFY_SSL throughout the codebase