### PR TITLE
PY-220 Disable source tracking on empty Git repos

### DIFF
--- a/src/neptune_scale/util/source_tracking.py
+++ b/src/neptune_scale/util/source_tracking.py
@@ -44,7 +44,12 @@ def read_repository_info(
     if git_repo is None:
         return None
 
-    head_commit = git_repo.head.commit
+    try:
+        head_commit = git_repo.head.commit
+    except ValueError:
+        # Happens when the repository is empty (no commits)
+        return None
+
     is_dirty = git_repo.is_dirty(index=False)
     active_branch = _get_active_branch(git_repo)
     remotes = {remote.name: remote.url for remote in git_repo.remotes}


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Bug Fixes:
- Catch ValueError when accessing head commit of an empty repository and return None to disable source tracking