### PR TITLE
Don't fast-fail e2e tests and limit time limit for e2e tests

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     runs-on: tools-gha-runners
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.9", "3.13" ]
         env_target: [ "AZURE", "GCP", "AWS" ]
@@ -37,7 +38,7 @@ jobs:
           pip install -r dev_requirements.txt
 
       - name: Run tests
-        timeout-minutes: 45
+        timeout-minutes: 20
         env:
           NEPTUNE_E2E_API_TOKEN: ${{ secrets[format('E2E_API_TOKEN_{0}', matrix.env_target)] }}
           NEPTUNE_E2E_PROJECT: ${{ secrets[format('E2E_PROJECT_{0}', matrix.env_target)] }}


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Disable fast-fail in the end-to-end test matrix and shorten the test step timeout

CI:
- Disable fail-fast for the e2e test strategy matrix
- Reduce the e2e test step timeout from 45 minutes to 20 minutes