### PR TITLE
Update log_timings

### DIFF
--- a/src/neptune_scale/sync/operations_repository.py
+++ b/src/neptune_scale/sync/operations_repository.py
@@ -875,7 +875,6 @@ class OperationsRepository:
                             os.remove(self._db_path)
                         except OSError:
                             logger.debug(f"Failed to delete SQLite database file {self._db_path}", exc_info=True)
-                            pass
                         logger.debug(f"Deleted SQLite database file {self._db_path}")
                     else:
                         self._connection.close()


### PR DESCRIPTION
1. Logged times should exclude time to fetch lock
2. Add pids to the output to better guess if users use multiprocessing or not

<img width="1901" height="857" alt="image" src="https://github.com/user-attachments/assets/c5e0e850-b4e4-4363-b6b7-83ca703cff17" />

## Summary by Sourcery

Refactor the log_timing decorator to use a new Timer context manager that scopes timing to the actual function body and passes it into all decorated methods, exclude lock/connection acquisition time from measurements, and enhance debug logs to include the process ID.

Enhancements:
- Replace inline timing logic with a Timer context manager driven by LOG_TIMING_THRESHOLD_MS
- Pass an optional Timer parameter into every repository method decorated by log_timing to bound the timed section
- Exclude time spent acquiring locks and connections from the logged durations
- Include the current process ID in all log_timing debug messages