### PR TITLE
Make OPERATION_REPOSITORY_TIMEOUT controllable by an undocumented env

### DIFF
--- a/src/neptune_scale/sync/operations_repository.py
+++ b/src/neptune_scale/sync/operations_repository.py
@@ -5,10 +5,7 @@ import logging
 import pickle
 from pathlib import Path
 
-from neptune_scale.sync.parameters import (
-    MAX_SINGLE_OPERATION_SIZE_BYTES,
-    OPERATION_REPOSITORY_TIMEOUT,
-)
+from neptune_scale.sync.parameters import MAX_SINGLE_OPERATION_SIZE_BYTES
 
 __all__ = (
     "OperationsRepository",
@@ -59,7 +56,6 @@ from neptune_scale.util import (
     envs,
     get_logger,
 )
-from neptune_scale.util.envs import LOG_TIMING_THRESHOLD_MS
 
 logger = get_logger()
 
@@ -82,7 +78,7 @@ def log_timing(func: Callable[..., R]) -> Callable[..., R]:
     if not logger.isEnabledFor(logging.DEBUG):
         return func
 
-    min_time_to_log_call_ms = float(os.getenv(LOG_TIMING_THRESHOLD_MS, "1000.0"))
+    min_time_to_log_call_ms = float(os.getenv(envs.LOG_TIMING_THRESHOLD_MS, "1000.0"))
 
     def represent_argument(name: Optional[str], value: object) -> str:
         if isinstance(value, OperationsRepository):
@@ -241,7 +237,7 @@ class OperationsRepository:
     def __init__(
         self,
         db_path: Path,
-        timeout: Optional[int] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         if not db_path.is_absolute():
             raise RuntimeError("db_path must be an absolute path")
@@ -250,7 +246,11 @@ class OperationsRepository:
         self._lock = threading.RLock()
         self._connection: Optional[sqlite3.Connection] = None
 
-        self._timeout = timeout if timeout is not None else OPERATION_REPOSITORY_TIMEOUT
+        self._timeout = (
+            timeout
+            if timeout is not None
+            else envs.get_positive_int(envs.OPERATION_REPOSITORY_TIMEOUT_MS, 60_000) / 1000.0
+        )
 
         self._log_failure_action: Literal["raise", "drop"] = envs.get_option(  # type: ignore
             envs.LOG_FAILURE_ACTION, ("drop", "raise"), "drop"

--- a/src/neptune_scale/sync/parameters.py
+++ b/src/neptune_scale/sync/parameters.py
@@ -28,7 +28,6 @@ MAX_REQUESTS_STATUS_BATCH_SIZE = 1000
 # Operations
 MAX_SINGLE_OPERATION_SIZE_BYTES = 2 * 1024 * 1024  # 2MB
 MAX_REQUEST_SIZE_BYTES = 16 * 1024 * 1024  # 16MB
-OPERATION_REPOSITORY_TIMEOUT = 60  # 1 minute
 # Maximum number of bytes in a single string series data point
 MAX_STRING_SERIES_DATA_POINT_LENGTH = 1024 * 1024
 # Max histogram bins = 512, thus max bin edges = 513

--- a/src/neptune_scale/util/envs.py
+++ b/src/neptune_scale/util/envs.py
@@ -27,6 +27,11 @@ MAX_CONCURRENT_FILE_UPLOADS = "NEPTUNE_MAX_CONCURRENT_FILE_UPLOADS"
 
 MODE_ENV_NAME = "NEPTUNE_MODE"
 
+# This gets passed to sqlite3.connect as the `timeout` parameter (after converting to seconds)
+# This controls how long the connection should wait when the database is locked by another connection
+# In the case of two processes trying to WRITE to our database
+OPERATION_REPOSITORY_TIMEOUT_MS = "NEPTUNE_OPERATION_REPOSITORY_TIMEOUT_MS"
+
 
 def get_bool(name: str, default_missing: bool, default_invalid: bool) -> bool:
     env_val = os.getenv(name)


### PR DESCRIPTION
## Summary by Sourcery

Make the operations repository timeout configurable through an environment variable, remove the hardcoded timeout constant, and update timer type hints and log timing source

New Features:
- Allow configuring SQLite connection timeout via NEPTUNE_OPERATION_REPOSITORY_TIMEOUT_MS environment variable

Chores:
- Remove hardcoded OPERATION_REPOSITORY_TIMEOUT constant and its import from parameters
- Add OPERATION_REPOSITORY_TIMEOUT_MS constant in util/envs for timeout configuration