### PR TITLE
feat: add inherit_configs flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ pattern = "default-unprefixed"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-neptune-api = ">=0.20.0,<0.23.0"
+neptune-api = ">=0.23.0,<0.24.0"
 more-itertools = "^10.0.0"
 psutil = ">=5.0.0"
 backoff = "^2.0.0"

--- a/src/neptune_scale/api/run.py
+++ b/src/neptune_scale/api/run.py
@@ -182,6 +182,7 @@ class Run(AbstractContextManager):
         enable_console_log_capture: bool = True,
         runtime_namespace: Optional[str] = None,
         source_tracking_config: Optional[SourceTrackingConfig] = SourceTrackingConfig(),
+        inherit_configs: bool = True,
         **kwargs: Any,
     ) -> None:
         """
@@ -216,6 +217,7 @@ class Run(AbstractContextManager):
             runtime_namespace: Attribute path prefix for the captured logs. If not provided, defaults to "runtime".
             source_tracking_config: Change or disable the logging of source code and Git information. To specify what
                 information to log, pass a `SourceTrackingConfig` object. To disable logging, set to `None`.
+            inherit_configs:
         """
 
         if run_id is None:
@@ -400,6 +402,7 @@ class Run(AbstractContextManager):
                 experiment_name=experiment_name,
                 fork_run_id=fork_run_id,
                 fork_step=fork_step,
+                inherit_configs=inherit_configs,
             )
             self._write_source_tracking_attributes(source_tracking_config)
 
@@ -538,6 +541,7 @@ class Run(AbstractContextManager):
         experiment_name: Optional[str],
         fork_run_id: Optional[str],
         fork_step: Optional[Union[int, float]],
+        inherit_configs: bool,
     ) -> None:
         if self._operations_repo is None:
             logger.debug("Run is in mode that doesn't support creating runs.")
@@ -556,6 +560,7 @@ class Run(AbstractContextManager):
             fork_point=fork_point,
             experiment_id=experiment_name,
             creation_time=None if creation_time is None else datetime_to_proto(creation_time),
+            inherit_configs=inherit_configs,
         )
 
         self._operations_repo.save_create_run(create_run)

--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -217,3 +217,32 @@ def test_source_tracking(run, client, project_name):
         assert file_ref["mime_type"] == "application/patch"
         assert file_ref["size_bytes"] == len(value)
         assert file_ref["path"] is not None
+
+
+@pytest.mark.parametrize(
+    "inherit_configs",
+    [True, False],
+)
+def test_inherit_configs(api_token, client, run, project_name, inherit_configs):
+    # given
+    now = time.time()
+    data = {
+        "int-value": int(now),
+        "float-value": now,
+        "str-value": f"hello-{now}",
+    }
+    run.log_configs(data)
+    assert run.wait_for_processing(SYNC_TIMEOUT)
+
+    # when
+    with Run(
+        api_token=api_token, project=project_name, fork_run_id=run._run_id, fork_step=0, inherit_configs=inherit_configs
+    ) as run_2:
+        pass
+
+    fetched = fetch_attribute_values(client, project_name, custom_run_id=run_2._run_id, attributes=data.keys())
+    for key, value in data.items():
+        if inherit_configs:
+            assert fetched[key] == value, f"Value for {key} does not match"
+        else:
+            assert key not in fetched, f"Value for {key} was inherited but should not be"


### PR DESCRIPTION
fixes PY-221

## Summary by Sourcery

Introduce inherit_configs flag on Run to allow enabling or disabling the inheritance of logged configurations when creating forked runs, and update the neptune-api dependency accordingly.

New Features:
- Add inherit_configs parameter to Run to control inheriting logged configurations when forking runs

Build:
- Bump neptune-api dependency to >=0.23.0,<0.24.0

Tests:
- Add end-to-end test to verify inherit_configs behavior for forked runs