### PR TITLE
fix: MetadataSplitter no longer generates empty updates

### DIFF
--- a/src/neptune_scale/sync/metadata_splitter.py
+++ b/src/neptune_scale/sync/metadata_splitter.py
@@ -116,21 +116,18 @@ class MetadataSplitter(Iterator[UpdateRunSnapshot]):
         self._file_series = peekable(self._stream_files(file_series)) if file_series else None
 
         self._max_update_bytes_size = max_message_bytes_size
-        self._has_returned = False
 
     def __iter__(self) -> MetadataSplitter:
-        self._has_returned = False
         return self
 
     def __next__(self) -> UpdateRunSnapshot:
         if (
-            self._has_returned
-            and not self._configs
-            and not self._metrics
-            and not self._add_tags
-            and not self._remove_tags
-            and not self._files
-            and not self._file_series
+            not bool(self._configs)
+            and not bool(self._metrics)
+            and not bool(self._add_tags)
+            and not bool(self._remove_tags)
+            and not bool(self._files)
+            and not bool(self._file_series)
         ):
             raise StopIteration
 
@@ -170,7 +167,6 @@ class MetadataSplitter(Iterator[UpdateRunSnapshot]):
             size=size,
         )
 
-        self._has_returned = True
         return update
 
     def populate_assign(


### PR DESCRIPTION
fixes PY-240

## Summary by Sourcery

Prevent MetadataSplitter from emitting empty update snapshots and update unit tests to align with the new behavior

Bug Fixes:
- Stop MetadataSplitter from yielding an empty UpdateRunSnapshot when there are no metadata operations to process

Enhancements:
- Convert pytest.mark.parametrize arguments from tuples to list literals for consistency

Tests:
- Change test_empty to expect zero results
- Add data initialization for all parameters in test_invalid_paths and iterate splitter with list() instead of next() to trigger StopIteration