### PR TITLE
fix: do not consider RUN_CONFLICTING error not a fatal run creation error

### DIFF
--- a/src/neptune_scale/exceptions.py
+++ b/src/neptune_scale/exceptions.py
@@ -48,6 +48,9 @@ __all__ = (
     "NeptuneHistogramTooManyBins",
     "NeptuneHistogramBinEdgesNotIncreasing",
     "NeptuneHistogramValuesLengthMismatch",
+    "NeptuneProjectAlreadyExists",
+    "NeptuneProjectError",
+    "NeptuneRunError",
 )
 
 from typing import (
@@ -339,7 +342,7 @@ class NeptuneRunDuplicate(NeptuneScaleWarning):
     )
 
 
-class NeptuneRunConflicting(NeptuneRunError):
+class NeptuneRunConflicting(NeptuneScaleWarning):
     message = """
 {h1}
 NeptuneRunConflicting: Run with specified `run_id` already exists, but has a different `fork_run_id` parameter.

--- a/tests/unit/test_sync_process.py
+++ b/tests/unit/test_sync_process.py
@@ -498,7 +498,6 @@ def test_status_thread_processes_element():
         ingest_pb2.IngestCode.PROJECT_INVALID_NAME,
         ingest_pb2.IngestCode.PROJECT_NOT_FOUND,
         ingest_pb2.IngestCode.RUN_NOT_FOUND,
-        ingest_pb2.IngestCode.RUN_CONFLICTING,
         ingest_pb2.IngestCode.RUN_INVALID_CREATION_PARAMETERS,
         # this error is skipped, tested separately in test_status_thread_skips_errors_that_should_not_be_reported
         ingest_pb2.IngestCode.FLOAT_VALUE_NAN_INF_UNSUPPORTED,
@@ -543,7 +542,6 @@ def test_status_thread_processes_element_with_standard_error_code(detail):
         ingest_pb2.IngestCode.PROJECT_INVALID_NAME,
         ingest_pb2.IngestCode.PROJECT_NOT_FOUND,
         ingest_pb2.IngestCode.RUN_NOT_FOUND,
-        ingest_pb2.IngestCode.RUN_CONFLICTING,
         ingest_pb2.IngestCode.RUN_INVALID_CREATION_PARAMETERS,
     ],
 )


### PR DESCRIPTION
towards PY-224
## Summary by Sourcery

Reclassify the RUN_CONFLICTING ingest code as a warning rather than an error by updating its exception class and adjusting the tests accordingly.

Bug Fixes:
- Do not treat RUN_CONFLICTING as a fatal run creation error

Enhancements:
- Change NeptuneRunConflicting to subclass NeptuneScaleWarning instead of NeptuneRunError

Tests:
- Remove RUN_CONFLICTING from the list of fatal ingest codes in sync process tests