### PR TITLE
fix: inherit_configs tests - add experiment_name variable (tests different experiment_name variants)

### DIFF
--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -223,7 +223,11 @@ def test_source_tracking(run, client, project_name):
     "inherit_configs",
     [True, False],
 )
-def test_inherit_configs(api_token, client, run, project_name, inherit_configs):
+@pytest.mark.parametrize(
+    "experiment_name",
+    ["pye2e-scale", "test_inherit_configs", None],
+)
+def test_inherit_configs(api_token, client, run, project_name, inherit_configs, experiment_name):
     # given
     now = time.time()
     data = {
@@ -246,7 +250,7 @@ def test_inherit_configs(api_token, client, run, project_name, inherit_configs):
         fork_run_id=run._run_id,
         fork_step=0,
         inherit_configs=inherit_configs,
-        experiment_name="test_inherit_configs",
+        experiment_name=experiment_name,
     ) as run_2:
         run_2.log_configs(data_2)
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance the inherit_configs end-to-end test to cover different experiment_name scenarios and verify proper config inheritance when forking runs

Tests:
- Parameterize test_inherit_configs with experiment_name values 'pye2e-scale', 'test_inherit_configs', and None
- Log a second set of config values in the forked run and fetch both original and new configs
- Assert that original configs are inherited only when inherit_configs is true and that new configs are always present